### PR TITLE
Namespace chaining

### DIFF
--- a/src/main/java/bsh/BlockNameSpace.java
+++ b/src/main/java/bsh/BlockNameSpace.java
@@ -66,16 +66,16 @@ class BlockNameSpace extends NameSpace
 		removed, but it cannot.  When recurse is false we still need to set the
 		variable in our parent, not here.
 	*/
-    public void	setVariable( 
-		String name, Object value, boolean strictJava, boolean recurse ) 
-		throws UtilEvalError 
+    public Variable	setVariable(
+		String name, Object value, boolean strictJava, boolean recurse )
+		throws UtilEvalError
 	{
-		if ( weHaveVar( name ) ) 
+		if ( weHaveVar( name ) )
 			// set the var here in the block namespace
-			super.setVariable( name, value, strictJava, false );
+			return super.setVariable( name, value, strictJava, false );
 		else
 			// set the var in the enclosing (parent) namespace
-			getParent().setVariable( name, value, strictJava, recurse );
+			return getParent().setVariable( name, value, strictJava, recurse );
     }
 
 	/**

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -192,7 +192,7 @@ public class Interpreter
 
 		BshClassManager bcm = BshClassManager.createClassManager( this );
 		if ( namespace == null )
-        	this.globalNameSpace = new NameSpace( bcm, "global");
+        	this.globalNameSpace = new NameSpace( null, bcm, "global");
 		else
 			this.globalNameSpace = namespace;
 
@@ -277,18 +277,18 @@ public class Interpreter
 	{
 		BshClassManager bcm = getClassManager();
 		// bsh
-		setu("bsh", new NameSpace( bcm, "Bsh Object" ).getThis( this ) );
+		setu("bsh", new NameSpace(null, bcm, "Bsh Object" ).getThis( this ) );
 
 		// init the static shared sharedObject if it's not there yet
 		if ( sharedObject == null )
-			sharedObject = new NameSpace( 
+			sharedObject = new NameSpace(null, 
 				bcm, "Bsh Shared System Object" ).getThis( this );
 		// bsh.system
 		setu( "bsh.system", sharedObject );
 		setu( "bsh.shared", sharedObject ); // alias
 
 		// bsh.help
-		This helpText = new NameSpace( 
+		This helpText = new NameSpace(null,
 			bcm, "Bsh Command Help Text" ).getThis( this );
 		setu( "bsh.help", helpText );
 

--- a/src/main/java/bsh/NameSpace.java
+++ b/src/main/java/bsh/NameSpace.java
@@ -77,7 +77,7 @@ public class NameSpace
 	*/
 	private String nsName; 
     private NameSpace parent;
-    private Hashtable variables;
+    private Hashtable<String, Variable> variables;
     private Hashtable methods;
 
     protected Hashtable importedClasses;
@@ -257,15 +257,15 @@ public class NameSpace
 	}
 
 	/**
-		Set a variable explicitly in the local scope.
+	Set a variable explicitly in the local scope.
 	*/
-    void setLocalVariable( 
-		String name, Object value, boolean strictJava ) 
-		throws UtilEvalError 
+	public Variable setLocalVariable(
+		String name, Object value, boolean strictJava )
+		throws UtilEvalError
 	{
-		setVariable( name, value, strictJava, false/*recurse*/ );
+		return setVariable( name, value, strictJava, false/*recurse*/ );
 	}
-
+	
 	/**
 		Set the value of a the variable 'name' through this namespace.
 		The variable may be an existing or non-existing variable.
@@ -289,9 +289,9 @@ public class NameSpace
 		@param recurse determines whether we will search for the variable in
 		  our parent's scope before assigning locally.
 	*/
-    void setVariable( 
-		String name, Object value, boolean strictJava, boolean recurse ) 
-		throws UtilEvalError 
+	Variable setVariable(
+		String name, Object value, boolean strictJava, boolean recurse )
+		throws UtilEvalError
 	{
 		if ( variables == null )
 			variables =	new Hashtable();
@@ -312,7 +312,8 @@ public class NameSpace
 				throw new UtilEvalError(
 					"Variable assignment: " + name + ": " + e.getMessage());
 			}
-		} else 
+			return existing;
+		} else
 		// No previous variable definition found here (or above if recurse)
 		{
 			if ( strictJava )
@@ -323,14 +324,15 @@ public class NameSpace
 			// If recurse, set global untyped var, else set it here.	
 			//NameSpace varScope = recurse ? getGlobal() : this;
 			// This modification makes default allocation local
-			NameSpace varScope = this;
-
-			varScope.variables.put( 
-				name, createVariable( name, value, null/*modifiers*/ ) );
-
+			//NameSpace varScope = this;
+			Variable var = createVariable( name, value, null/*modifiers*/ );
+			this.variables.put(
+				name, var );
+	
 			// nameSpaceChanged() on new variable addition
 			nameSpaceChanged();
-    	}
+			return var;
+		}
 	}
     
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/bsh/NameSpace.java
+++ b/src/main/java/bsh/NameSpace.java
@@ -61,8 +61,9 @@ public class NameSpace
 	implements java.io.Serializable, BshClassManager.Listener, 
 	NameSource
 {
-	public static final NameSpace JAVACODE = 
-		new NameSpace((BshClassManager)null, "Called from compiled Java code.");
+	public static final NameSpace JAVACODE =
+			// (BshClassManager)
+		new NameSpace(null, null, "Called from compiled Java code.");
 	static {
 		JAVACODE.isMethod = true;
 	}
@@ -165,10 +166,10 @@ public class NameSpace
 		this( parent, null, name );
 	}
 
-    public NameSpace( BshClassManager classManager, String name ) 
-	{
-		this( null, classManager, name );
-	}
+//    public NameSpace( BshClassManager classManager, String name )
+//	{
+//		this( null, classManager, name );
+//	}
 
     public NameSpace( 
 		NameSpace parent, BshClassManager classManager, String name ) 

--- a/src/main/java/bsh/Variable.java
+++ b/src/main/java/bsh/Variable.java
@@ -88,23 +88,24 @@ public class Variable implements java.io.Serializable
 		if ( hasModifier("final") && this.value != null )
 			throw new UtilEvalError ("Final variable, can't re-assign.");
 
-		if ( value == null )
-			value = Primitive.getDefaultValue( type );
+		this.value = value;
+
+		if ( this.value == null )
+			this.value = Primitive.getDefaultValue( type );
 
 		if ( lhs != null )
 		{
-			lhs.assign( Primitive.unwrap(value), false/*strictjava*/ );
+			this.value = lhs.assign( Primitive.unwrap(value), false/*strictjava*/ );
 			return;
 		}
 
 		// TODO: should add isJavaCastable() test for strictJava
 		// (as opposed to isJavaAssignable())
 		if ( type != null )
-			value = Types.castObject( value, type, 
+			this.value = Types.castObject( value, type,
 				context == DECLARATION ? Types.CAST : Types.ASSIGNMENT
 			);
 
-		this.value= value;
 	}
 
 	/*

--- a/src/test/java/bsh/Namespace_chaining.java
+++ b/src/test/java/bsh/Namespace_chaining.java
@@ -35,7 +35,7 @@ public class Namespace_chaining {
 
     @Test
     public void namespace_nesting() throws UtilEvalError {
-        final NameSpace root = new NameSpace((NameSpace) null, "root");
+        final NameSpace root = new NameSpace( null, "root");
         final NameSpace child = new NameSpace(root, "child");
 
         root.setLocalVariable("bar", 42, false);


### PR DESCRIPTION
Resolve IllegalAccesException calling setVariable.

Basically the compiler has a problem with us creating creating new objects without the caller
having a reference. So we want to get the new variable reference back and have the variable
update itself via reference

Ambiguous constructor for NameSpace.

Casting the null references won't cut it anymore, the signature java has is  (null, String)
and there are two constructors that satisfy this. Commented one of them out as a
quick fix.

Namespace chaining test now succeeds.