### PR TITLE
Prompt management in console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,12 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
-
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.16.1</version>
+      <scope>test</scope>
+      <type>jar</type>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/bsh/ConsoleInterface.java
+++ b/src/main/java/bsh/ConsoleInterface.java
@@ -43,5 +43,6 @@ public interface ConsoleInterface {
     public void println( Object o );
     public void print( Object o );
     public void error( Object o );
+    public void prompt( String prompt ); 
 }
 

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -484,7 +484,7 @@ public class Interpreter
                 Thread.yield();  // this helps a little
 
                 if ( interactive )
-                    print( getBshPrompt() );
+                    prompt(getBshPrompt());
 
                 eof = Line();
 
@@ -1292,6 +1292,11 @@ public class Interpreter
 
     public static boolean getSaveClasses()  {
         return getSaveClassesDir() != null && !getSaveClassesDir().isEmpty();
+    }
+
+    @Override
+    public void prompt(String prompt) {
+        print(prompt);
     }
 }
 

--- a/src/main/java/bsh/util/AWTConsole.java
+++ b/src/main/java/bsh/util/AWTConsole.java
@@ -25,6 +25,8 @@
  *****************************************************************************/
 package bsh.util;
 
+import bsh.ConsoleInterface;
+import bsh.Interpreter;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Frame;
@@ -43,9 +45,6 @@ import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.util.Vector;
-
-import bsh.ConsoleInterface;
-import bsh.Interpreter;
 
 /*
     This should go away eventually...  Native AWT sucks.
@@ -350,4 +349,9 @@ public class AWTConsole extends TextArea
     // unused
     public void keyTyped(KeyEvent e) { }
     public void keyReleased(KeyEvent e) { }
+
+    @Override
+    public void prompt(String prompt) {
+        print(prompt);
+    }
 }

--- a/src/main/java/bsh/util/JConsole.java
+++ b/src/main/java/bsh/util/JConsole.java
@@ -49,7 +49,6 @@ import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.util.Vector;
-
 import javax.swing.Icon;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -760,6 +759,11 @@ public class JConsole extends JScrollPane
         } else {
             run.run();
         }
+    }
+
+    @Override
+    public void prompt(String prompt) {
+        print(prompt);
     }
 
     /**

--- a/src/test/java/bsh/InterpreterConsoleTest.java
+++ b/src/test/java/bsh/InterpreterConsoleTest.java
@@ -1,0 +1,175 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+/****************************************************************************/
+
+package bsh;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.io.StringReader;
+import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+public class InterpreterConsoleTest {
+
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+
+    /**
+     * <a href="http://code.google.com/p/beanshell2/issues/detail?id=50">Issue #50</a>
+     */
+
+    @Test
+    public void read_from_provieded_reader() throws Exception {
+        final StringReader r = new StringReader("var = \"hello\";");
+
+        exit.expectSystemExit();
+
+        Interpreter bsh = new Interpreter(givenConsole(r));
+        bsh.run();
+
+        assertEquals("hello", bsh.get("var"));
+    }
+
+    @Test
+    public void write_to_provieded_printer() throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        final StringReader r = new StringReader("print(\"hello\");");
+        final PrintStream p = new PrintStream(baos);
+
+        exit.expectSystemExit();
+
+        Interpreter bsh = new Interpreter(givenConsole(r, p));
+        bsh.run();
+
+        assertEquals("hello", baos.toString());
+    }
+
+    @Test
+    public void write_to_provieded_error() throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        final StringReader r = new StringReader("error(\"hello\");");
+        final PrintStream p = new PrintStream(baos);
+
+        exit.expectSystemExit();
+
+        Interpreter bsh = new Interpreter(givenConsole(r, p));
+        bsh.run();
+
+        assertEquals("// Error: hello", baos.toString());
+    }
+
+    @Test
+    public void set_prompt_at_start() {
+        final ByteArrayOutputStream w = new ByteArrayOutputStream();
+        final StringReader r = new StringReader("");
+
+        exit.expectSystemExit();
+
+        ConsoleInterface console = givenConsole(r, new PrintStream(w));
+        Interpreter bsh = new Interpreter(console);
+        bsh.run();
+
+        assertEquals("bsh", w.toString());
+    }
+
+    @Test
+    public void set_prompt_when_needed() {
+        final ByteArrayOutputStream w = new ByteArrayOutputStream();
+        final StringReader r = new StringReader("\n");
+
+        exit.expectSystemExit();
+
+        ConsoleInterface console = givenConsole(r, new PrintStream(w));
+        Interpreter bsh = new Interpreter(console);
+        bsh.run();
+
+        assertEquals("bsh", w.toString());
+    }
+
+    // --------------------------------------------------------- private methods
+
+    private ConsoleInterface givenConsole(Reader in) {
+        return givenConsole(in, null, null);
+    }
+
+    private ConsoleInterface givenConsole(Reader in, PrintStream out) {
+        return givenConsole(in, out, null);
+    }
+
+    private ConsoleInterface givenConsole(final Reader in, final PrintStream out, final PrintStream err) {
+        return new TestingConsole(in, out, err);
+    }
+
+    // ---------------------------------------------------------- TestingConsole
+
+    private static class TestingConsole implements ConsoleInterface {
+        private String prompt;
+        private Reader in;
+        private PrintStream out, err;
+
+        public TestingConsole(Reader in, PrintStream out, PrintStream err) {
+            this.in = in;
+            this.out = out;
+            this.err = err;
+        }
+        @Override
+        public Reader getIn() {
+            return (in == null) ? new InputStreamReader(System.in) : in;
+        }
+
+        @Override
+        public PrintStream getOut() {
+            return (out == null) ? System.out : out;
+        }
+
+        @Override
+        public PrintStream getErr() {
+            return (err == null) ? System.err : out;
+        }
+
+        @Override
+        public void println(Object o) {
+            getOut().println(o);
+        }
+
+        @Override
+        public void print(Object o) {
+            getOut().print(o);
+        }
+
+        @Override
+        public void error(Object o) {
+            getErr().println(o);
+        }
+
+        @Override
+        public void prompt(String prompt) {
+            this.prompt = prompt;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR is to delegate the management of the prompt to the the ConsoleInterface. This allows a better integration with console libraries which usually manage the prompt on their own. It seems to be a functionality closer to the responsibility of the console rather than the interpreter.

It fundamentally adds a prompt() method to ConsoleInterface so that when Interpreter needs to show the prompt it calls the ConsoleInterface method. The code will probably explain it better than my words :)