### PR TITLE
Add system independent properties for line and path separator

### DIFF
--- a/src/test/java/bsh/classpath/BshClassPathTest.java
+++ b/src/test/java/bsh/classpath/BshClassPathTest.java
@@ -117,7 +117,7 @@ public class BshClassPathTest {
     @Test
     public void classpath_map_filesystem_exception() throws Exception {
         thrown.expect(FileSystemNotFoundException.class);
-	String unknownString = File.separator+"unknown"+File.separator+"path";
+        String unknownString = File.separator+"unknown"+File.separator+"path";
         thrown.expectMessage(containsString(unknownString));
 
         try (final Interpreter bsh = new Interpreter()) {

--- a/src/test/java/bsh/classpath/BshClassPathTest.java
+++ b/src/test/java/bsh/classpath/BshClassPathTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.net.URL;
 import java.nio.file.FileSystemNotFoundException;
 import java.util.ArrayList;
@@ -116,7 +117,8 @@ public class BshClassPathTest {
     @Test
     public void classpath_map_filesystem_exception() throws Exception {
         thrown.expect(FileSystemNotFoundException.class);
-        thrown.expectMessage(containsString("/unknown/path"));
+	String unknownString = File.separator+"unknown"+File.separator+"path";
+        thrown.expectMessage(containsString(unknownString));
 
         try (final Interpreter bsh = new Interpreter()) {
             ClassManagerImpl cm = (ClassManagerImpl) bsh.getNameSpace().getClassManager();

--- a/src/test/resources/test-scripts/strings.bsh
+++ b/src/test/resources/test-scripts/strings.bsh
@@ -70,9 +70,9 @@ assertEquals("?77", "\7777");
 assertEquals("Is a question?", "Is a question\77");
 
 // Long strings
-out= System.getProperty("line.separator");
+out= "\n";
 for (x : 5)
-  out += x + System.getProperty("line.separator");
+  out += x + "\n";
 
 aout = """
 0
@@ -82,7 +82,7 @@ aout = """
 4
 5
 """;
-assert(aout.equals(out));
+assert(aout.replace("\r","").equals(out));
 
 assert("""
 This is a long string

--- a/src/test/resources/test-scripts/strings.bsh
+++ b/src/test/resources/test-scripts/strings.bsh
@@ -70,9 +70,9 @@ assertEquals("?77", "\7777");
 assertEquals("Is a question?", "Is a question\77");
 
 // Long strings
-out="\n";
+out= System.getProperty("line.separator");
 for (x : 5)
-  out += x + "\n";
+  out += x + System.getProperty("line.separator");
 
 aout = """
 0


### PR DESCRIPTION
This patch fixes a couple of tests that were failing in a Window environment.  It replaces the hardcoded path and line separator characters with system properties.