### PR TITLE
Add two mechanisms for dealing with voids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ BeanShell.ipr
 BeanShell.iws
 *gradle*
 *.ser
+.idea/

--- a/src/main/java/bsh/Capabilities.java
+++ b/src/main/java/bsh/Capabilities.java
@@ -48,12 +48,21 @@ public class Capabilities implements Supplier<Boolean>, Consumer<Boolean>
     static final Capabilities instance = new Capabilities();
     private volatile boolean accessibility = false;
     private static final ThreadLocal<Boolean> ACCESSIBILITY = ThreadLocal.withInitial(Capabilities.instance);
+    private static final ThreadLocal<Boolean> VOID_TO_NULL = ThreadLocal.withInitial(() -> false);
 
     private Capabilities() {}
 
     public static boolean haveSwing() {
         // classExists caches info for us
         return classExists( "javax.swing.JButton" );
+    }
+
+    public static boolean haveVoidToNull() {
+        return VOID_TO_NULL.get();
+    }
+
+    public static void setVoidToNull(final boolean b) {
+        VOID_TO_NULL.set(b);
     }
 
     /**

--- a/src/main/java/bsh/This.java
+++ b/src/main/java/bsh/This.java
@@ -57,6 +57,8 @@ import java.util.stream.Stream;
 */
 public final class This implements java.io.Serializable, Runnable
 {
+    public static final String PROPERTY_MISSING_HOOK = "propertyMissing";
+
     enum Keys {
         /** The name of the static field holding the reference to the bsh
          * static This (the callback namespace for static methods) */
@@ -384,6 +386,14 @@ public final class This implements java.io.Serializable, Runnable
 
         if ( bshMethod != null )
             return bshMethod.invoke( args, interpreter, callstack, callerInfo );
+
+        // Do NOT forward on to invoke for missingProperty
+        if (methodName.equals(This.PROPERTY_MISSING_HOOK) && args.length == 1) {
+            throw new EvalError("Method " +
+                    StringUtil.methodString( methodName, types ) +
+                    " not found in bsh scripted object: "+ namespace.getName(),
+                    callerInfo, callstack );
+        }
 
         /*
             No scripted method of that name.

--- a/src/test/java/bsh/SafeVoidTest.java
+++ b/src/test/java/bsh/SafeVoidTest.java
@@ -1,0 +1,34 @@
+package bsh;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static bsh.TestUtil.eval;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+
+@RunWith(FilteredTestRunner.class)
+public class SafeVoidTest {
+
+    @Test
+    public void void_to_null_returns_null() throws Exception {
+        Capabilities.setVoidToNull(true);
+        try {
+            assertTrue(Capabilities.haveVoidToNull());
+            String CODE_void_to_null = "b = a; return b";
+            assertNull(eval(CODE_void_to_null));
+            Capabilities.setVoidToNull(false);
+            try {
+                eval(CODE_void_to_null);
+                fail("Void to null check should have failed with capability disabled");
+            } catch(EvalError e) {
+                /* This is what we expect so ignore it */
+            }
+        } finally {
+            Capabilities.setVoidToNull(false);
+        }
+    }
+
+}

--- a/src/test/resources/test-scripts/missingproperty.bsh
+++ b/src/test/resources/test-scripts/missingproperty.bsh
@@ -1,0 +1,17 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+
+/*
+ * Define a missing property hook to return the value 'missing'
+ */
+propertyMissing(name) {
+    return "missing";
+}
+
+a = "found";
+
+assert(a.equals("found"));
+assert(b.equals("missing"));
+
+complete();


### PR DESCRIPTION
Added two mechanisms for dealing with `void`s in Beanshell: a propertyMissing(name) method that will be invoked when any variable cannot be resolved and an optional Capability to transform all void values to nulls during evaluation.

For issue #538 