### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 sudo: false
 script:
   - jdk_switcher use oraclejdk8


### PR DESCRIPTION
I recognized during my last PR, that the travis-ci build fails at `jdk_switcher`.
Luckily this can be fixed by adding just one line to .travis.yml