### PR TITLE
Fix NPE when doing "import *;"

### DIFF
--- a/src/main/java/bsh/BSHImportDeclaration.java
+++ b/src/main/java/bsh/BSHImportDeclaration.java
@@ -41,59 +41,60 @@ class BSHImportDeclaration extends SimpleNode
         throws EvalError
     {
         NameSpace namespace = callstack.top();
-        BSHAmbiguousName ambigName = (BSHAmbiguousName) jjtGetChild(0);
         if ( superImport ) try {
             namespace.doSuperImport();
         } catch ( UtilEvalError e ) {
             throw e.toEvalError( this, callstack  );
         }
-        else if ( staticImport ) {
-            if ( importPackage ) {
-                // import all (*) static members
-                Class<?> clas = ambigName.toClass( callstack, interpreter );
-                namespace.importStatic( clas );
-            } else {
-                Object obj = null;
-                Class<?> clas = null;
-                String name = Name.suffix(ambigName.text, 1);
-                try { // import static method from class
-                    clas = namespace.getClass(Name.prefix(ambigName.text));
-                    obj = Reflect.staticMethodImport(clas, name);
-                } catch (Exception e) { e.printStackTrace(); /* ignore try field instead */ }
-                try { // import static field from class
-                    if (null != clas && null == obj)
-                        obj = Reflect.getLHSStaticField(clas, name);
-                } catch (Exception e) { /* ignore try method instead */ }
-                try { // import static method from Name
-                    if (null == obj)
-                        obj = ambigName.toObject( callstack, interpreter );
-                } catch (Exception e) { /* ignore try field instead */ }
-                // do we have a method
-                if ( obj instanceof BshMethod ) {
-                    namespace.setMethod( (BshMethod) obj );
-                    return Primitive.VOID;
+        else {
+            BSHAmbiguousName ambigName = (BSHAmbiguousName) jjtGetChild(0);
+            if ( staticImport ) {
+                if ( importPackage ) {
+                    // import all (*) static members
+                    Class<?> clas = ambigName.toClass( callstack, interpreter );
+                    namespace.importStatic( clas );
+                } else {
+                    Object obj = null;
+                    Class<?> clas = null;
+                    String name = Name.suffix(ambigName.text, 1);
+                    try { // import static method from class
+                        clas = namespace.getClass(Name.prefix(ambigName.text));
+                        obj = Reflect.staticMethodImport(clas, name);
+                    } catch (Exception e) { e.printStackTrace(); /* ignore try field instead */ }
+                    try { // import static field from class
+                        if (null != clas && null == obj)
+                            obj = Reflect.getLHSStaticField(clas, name);
+                    } catch (Exception e) { /* ignore try method instead */ }
+                    try { // import static method from Name
+                        if (null == obj)
+                            obj = ambigName.toObject( callstack, interpreter );
+                    } catch (Exception e) { /* ignore try field instead */ }
+                    // do we have a method
+                    if ( obj instanceof BshMethod ) {
+                        namespace.setMethod( (BshMethod) obj );
+                        return Primitive.VOID;
+                    }
+                    if ( !(obj instanceof LHS) )
+                        // import static field from Name
+                        obj = ambigName.toLHS( callstack, interpreter );
+                    // do we have a field
+                    if ( obj instanceof LHS && ((LHS) obj).isStatic() ) {
+                        namespace.setVariableImpl( ((LHS) obj).getVariable() );
+                        return Primitive.VOID;
+                    }
+                    // no static member found
+                    throw new EvalError(ambigName.text
+                                        + " is not a static member of a class",
+                                        this, callstack );
                 }
-                if ( !(obj instanceof LHS) )
-                    // import static field from Name
-                    obj = ambigName.toLHS( callstack, interpreter );
-                // do we have a field
-                if ( obj instanceof LHS && ((LHS) obj).isStatic() ) {
-                    namespace.setVariableImpl( ((LHS) obj).getVariable() );
-                    return Primitive.VOID;
-                }
-                // no static member found
-                throw new EvalError(ambigName.text
-                        + " is not a static member of a class",
-                        this, callstack );
+            } else { // import package
+                String name = ambigName.text;
+                if ( importPackage )
+                    namespace.importPackage(name);
+                else
+                    namespace.importClass(name);
             }
-        } else { // import package
-            String name = ambigName.text;
-            if ( importPackage )
-                namespace.importPackage(name);
-            else
-                namespace.importClass(name);
         }
-
         return Primitive.VOID;
     }
 }

--- a/src/main/java/bsh/NameSpace.java
+++ b/src/main/java/bsh/NameSpace.java
@@ -1140,9 +1140,21 @@ public class NameSpace
         this.nameSourceListeners.add(listener);
     }
 
-    /** Perform "import *;" causing the entire classpath to be mapped. This can
+    /** 
+     * Perform "import *;" causing the entire classpath to be mapped. This can
      * take a while.
-     * @throws UtilEvalError the util eval error */
+     * <p>
+     * Super imports are different than regular imports.
+     * They are done in the context of the ClassManager 
+     * rather than the NameSpace and thus their effects
+     * may persist after the NameSpace is released.
+     *
+     * It seems irregular that named imports are 'local' to the
+     * namespace but super imports are 'global' to the class manager
+     * but I suppose for performance reasons it is a good idea
+     * to scan the super class path only once and store the results.
+     * @throws UtilEvalError the util eval error
+     */
     public void doSuperImport() throws UtilEvalError {
         this.getClassManager().doSuperImport();
     }

--- a/src/main/resources/bsh/commands/print.bsh
+++ b/src/main/resources/bsh/commands/print.bsh
@@ -20,10 +20,11 @@ bsh.help.print = "usage: print( value )";
 
 void print( arg )
 {
-    if ( arg instanceof String
+	// Other packages are known to define a String class so best practice here to disambiguate
+    if ( arg instanceof java.lang.String
             || (arg instanceof Primitive && arg.getType() == Character.TYPE)
             || arg instanceof CharSequence )
-        this.interpreter.println( String.valueOf(arg) );
+        this.interpreter.println( java.lang.String.valueOf(arg) );
     else
         this.interpreter.println( valueString(arg) + " :" + typeString(arg) );
 }

--- a/src/test/java/bsh/classpath/BshClassPathTest.java
+++ b/src/test/java/bsh/classpath/BshClassPathTest.java
@@ -85,6 +85,11 @@ public class BshClassPathTest {
         final Interpreter bsh = new Interpreter();
         ClassManagerImpl cm = (ClassManagerImpl) bsh.getNameSpace().getClassManager();
         BshClassPath bcp =  cm.getClassPath();
+        /*
+         * Since this is a unit test we will need to clear
+         * cached values for this test to work reliably
+         */
+        bcp.getBootClassPath().classPathChanged();
         bcp.getAllNames();
         assertTrue("Got feedback start", cpmf.start);
         assertTrue("Got feedback end", cpmf.end);

--- a/src/test/resources/test-scripts/import5.bsh
+++ b/src/test/resources/test-scripts/import5.bsh
@@ -1,0 +1,28 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+
+/*
+    Test wildcard import
+*/
+
+// mypackage is not imported yet
+assert( this.namespace.getClass("MyClass") == null );
+
+foo() {
+	// Use a superImport to import all classes in all packages
+    import *;
+    assert( this.namespace.getClass("MyClass") != null );
+}
+
+foo();
+
+/*
+ * superImport will be invoked in context of the parent class manager
+ * and will be visible in all parent namespaces.
+ */
+assert( this.namespace.getClass("MyClass") != null );
+
+
+
+complete();


### PR DESCRIPTION
Move the accessor for ambigName to after the check for superImport. If doing a superImport the ambigName access will cause an NPE, yet the ambigName is not required for this case.