### PR TITLE
Add test that ParseException has currentToken filled in

### DIFF
--- a/src/test/resources/test-scripts/exceptions5.bsh
+++ b/src/test/resources/test-scripts/exceptions5.bsh
@@ -1,0 +1,17 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+import bsh.ParseException;
+
+// Check that ParseException info is filled out, issue #395
+try { 
+  // Deliberate syntax error
+  eval("Number num = (Number a;");
+} catch ( ParseException pe ) { 
+  flag();
+  assert( pe.getErrorLineNumber() == 1 );
+}
+
+assert( flag() == 1 );
+
+complete();


### PR DESCRIPTION
Issue #395 indicated NPE on ParseException method getCurrentLineNumber().  This is fixed in the current code base but add this test anyway.