### PR TITLE
scripts/bsh: Grep correct bsh.Interpreter class signature

### DIFF
--- a/scripts/bsh
+++ b/scripts/bsh
@@ -36,7 +36,7 @@ fi
 # avoid extra bsh junk.
 #
 if [ "$NOBSHCHECK" ] || javap bsh.Interpreter 2>&1 |
-    grep 'public class bsh.Interpreter extends' > /dev/null
+    grep 'public class bsh.Interpreter' > /dev/null
 then
     # Have bsh
     java $debug bsh.Interpreter $*

--- a/scripts/bshd
+++ b/scripts/bshd
@@ -36,7 +36,7 @@ fi
 # avoid extra bsh junk.
 #
 if [ "$NOBSHCHECK" ] || javap bsh.Interpreter 2>&1 |
-    grep 'public class bsh.Interpreter extends' > /dev/null
+    grep 'public class bsh.Interpreter' > /dev/null
 then
     # Have bsh
     java $debug bsh.Interpreter $*


### PR DESCRIPTION
It looks like in the past bsh.Interpreter extended another class but that's not correct anymore. To grep just the class name in bsh shell scripts should be a more future proof approach.