### PR TITLE
Fix method overload resolution error in bshdoc.bsh

### DIFF
--- a/scripts/bshdoc.bsh
+++ b/scripts/bshdoc.bsh
@@ -89,7 +89,7 @@ printComment( String text )
 /**
 	bshdoc file comment.
 */
-bshdoc( filename ) 
+bshdoc( String filename ) 
 {
 	print("<File>");
 	tab();


### PR DESCRIPTION
Without this patch, `docs/manual/bshcommands-bshdoc.xml` doesn't build correctly because of an overload resolution problem in `bshdoc.bsh`. 

You'll see in the released `bsh-2.1.0-src.zip` the contents of `bshcommands-bshdoc.xml` are

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-stylesheet type="text/xsl" href="bshcommands.xsl"?>
<!-- This file was auto-generated by the bshdoc.bsh script -->
<BshDoc>
Evaluation Error: bsh.EvalError: Sourced file: /Users/jim/src/misc/beanshell/scripts/bshdoc.bsh : Invalid argument: `filenames' for method: bshdoc : Can't assign java.lang.String to java.lang.String [] : at Line: 159 : in file: /Users/jim/src/misc/beanshell/scripts/bshdoc.bsh : bshdoc ( filenames [ i ] ) 
```