### PR TITLE
fix broken 2.1.0 build of bsh-engine.jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,7 +18,7 @@
 
 	<property name="ant.build.javac.target" value="1.6" />
 	<property name="ant.build.javac.source" value="1.6" />
-	<property name="version" value="2.1.0"/>
+	<property name="version" value="2.1.1"/>
 	<property name="deprecation" value="on"/>
 	<property name="Specification-Title" value="BeanShell" />
 	<property name="Specification-Version" value="${version}" />

--- a/engine/src/bsh/engine/BshScriptEngine.java
+++ b/engine/src/bsh/engine/BshScriptEngine.java
@@ -1,5 +1,6 @@
-package bsh;
+package bsh.engine;
 
+import bsh.*;
 import javax.script.AbstractScriptEngine;
 import javax.script.Bindings;
 import javax.script.Compilable;

--- a/engine/src/bsh/engine/BshScriptEngineFactory.java
+++ b/engine/src/bsh/engine/BshScriptEngineFactory.java
@@ -1,5 +1,6 @@
-package bsh;
+package bsh.engine;
 
+import bsh.Interpreter;
 import javax.script.ScriptEngine;
 import java.util.List;
 import java.util.Arrays;

--- a/engine/src/bsh/engine/ScriptContextEngineView.java
+++ b/engine/src/bsh/engine/ScriptContextEngineView.java
@@ -1,4 +1,4 @@
-package bsh;
+package bsh.engine;
 
 import javax.script.ScriptContext;
 import java.util.Collection;


### PR DESCRIPTION
Apply to tag 2.1.0 to fix broken build of bsh-engine.jar, bump version to 2.1.1.