### PR TITLE
Revert "Grammar optimisation reducing 17 productions down to 4."

### DIFF
--- a/src/main/jjtree/bsh.jjt
+++ b/src/main/jjtree/bsh.jjt
@@ -776,67 +776,171 @@ int AssignmentOperator() :
 }
 
 void ConditionalExpression() :
-{ Token t; }
+{ }
 {
-  RelationalExpression() (  "?" ConditionalExpression() ":" ConditionalExpression() #TernaryExpression(3)
-  |
-  ( (t="||" | t="@or" | t="&&" | t="@and") RelationalExpression()
+  ConditionalOrExpression() [ "?" Expression() ":" ConditionalExpression()
+    #TernaryExpression(3) ]
+}
+
+void ConditionalOrExpression() :
+{ Token t=null; }
+{
+  ConditionalAndExpression()
+  ( ( t = "||" | t = "@or" )
+    ConditionalAndExpression()
         { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
-  )
+}
+
+void ConditionalAndExpression() :
+{ Token t=null; }
+{
+  InclusiveOrExpression()
+  ( ( t = "&&" | t = "@and" )
+    InclusiveOrExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void InclusiveOrExpression() :
+{ Token t=null; }
+{
+  ExclusiveOrExpression()
+  ( ( t = "|" | t = "@bitwise_or" )
+    ExclusiveOrExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void ExclusiveOrExpression() :
+{ Token t=null; }
+{
+  AndExpression() ( (t="^" | t = "@bitwise_xor") AndExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void AndExpression() :
+{ Token t=null; }
+{
+  EqualityExpression()
+  ( ( t = "&" | t = "@bitwise_and" )
+    EqualityExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void EqualityExpression() :
+{ Token t = null; }
+{
+  InstanceOfExpression() ( ( t= "==" | t= "!=" ) InstanceOfExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2)
+  )*
+}
+
+void InstanceOfExpression() :
+{ Token t = null; }
+{
+  RelationalExpression()
+  [ t = "instanceof" Type() { jjtThis.kind = t.kind; } #BinaryExpression(2) ]
 }
 
 void RelationalExpression() :
-{ Token t; }
+{ Token t = null; }
 {
-  BinaryExpression() (
-    t="instanceof" Type() { jjtThis.kind = t.kind; } #BinaryExpression(2)
-    |
-    ((t="==" | t="!=" | t="<" | t="@lt" | t=">" | t="@gt" | t="<="
-            | t="@lteq" | t=">=" | t="@gteq") BinaryExpression()
+  ShiftExpression()
+  ( ( t = "<" | t = "@lt" | t = ">" | t = "@gt" |
+      t = "<=" | t = "@lteq" | t = ">=" | t = "@gteq" )
+  ShiftExpression()
         { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
-  )
 }
 
-void BinaryExpression() :
-{ Token t; }
+void ShiftExpression() :
+{ Token t = null; }
 {
-  UnaryExpression() ( (t="+" | t="-" | t="*" | t="/" | t="%" | t="@mod"
-        | t="**" | t="@pow" | t="<<" | t="@left_shift" | t=">>"
-        | t="@right_shift" | t=">>>" | t="@right_unsigned_shift" | t="|"
-        | t="@bitwise_or" | t="^" | t="@bitwise_xor" | t="&"
-        | t="@bitwise_and")
-    UnaryExpression() { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+  AdditiveExpression()
+  ( ( t = "<<" | t = "@left_shift" | t = ">>" | t = "@right_shift" |
+      t = ">>>" | t = "@right_unsigned_shift" )
+  AdditiveExpression()
+  { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void AdditiveExpression() :
+{ Token t = null; }
+{
+  MultiplicativeExpression()
+  ( ( t= "+" | t= "-" ) MultiplicativeExpression() { jjtThis.kind = t.kind; }
+    #BinaryExpression(2)
+  )*
+}
+
+void MultiplicativeExpression() :
+{ Token t = null; }
+{
+  UnaryExpression() ( ( t= "*" | t= "/" | t= "%" | t = "@mod" | t= "**" | t = "@pow")
+  UnaryExpression() { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
 }
 
 void UnaryExpression() :
-{ Token t; }
+{ Token t = null; }
 {
-  (t="+" | t="-" | t="~" | t="!") UnaryExpression()
+  ( t="+" | t="-" ) UnaryExpression()
     { jjtThis.kind = t.kind; } #UnaryExpression(1)
 |
-  (t="++" | t="--") PrimaryExpression()
+  PreIncrementExpression()
+|
+  PreDecrementExpression()
+|
+  UnaryExpressionNotPlusMinus()
+}
+
+void PreIncrementExpression() :
+{ Token t = null; }
+{
+  t="++" PrimaryExpression()
+    { jjtThis.kind = t.kind; } #UnaryExpression(1)
+}
+
+void PreDecrementExpression() :
+{ Token t = null; }
+{
+  t="--" PrimaryExpression()
+    { jjtThis.kind = t.kind; } #UnaryExpression(1)
+}
+
+void UnaryExpressionNotPlusMinus() :
+{ Token t = null; }
+{
+  ( t="~" | t="!" ) UnaryExpression()
     { jjtThis.kind = t.kind; } #UnaryExpression(1)
 |
   LOOKAHEAD( CastLookahead() ) CastExpression()
 |
-  PrimaryExpression() [ (t="++" | t="--")
-    { jjtThis.kind = t.kind; jjtThis.postfix = true; } #UnaryExpression(1) ]
+  PostfixExpression()
 }
 
 // This production is to determine lookahead only.
-void CastLookahead() :
-{ }
+void CastLookahead() : { }
 {
-  "(" ( PrimitiveType()
-  | AmbiguousName() ( "[" | ")"
-    ("~" | "!" | "(" | <IDENTIFIER> | "new" | Literal() | ArrayDimensions()))
-  )
+  LOOKAHEAD(2) "(" PrimitiveType()
+|
+  LOOKAHEAD( "(" AmbiguousName() "[" ) "(" AmbiguousName() "[" "]"
+|
+  "(" AmbiguousName() ")" ( "~" | "!" | "(" | <IDENTIFIER> | /* "this" | "super" | */ "new" | Literal() | ArrayDimensions() )
+}
+
+void PostfixExpression() :
+{ Token t = null; }
+{
+  LOOKAHEAD( PrimaryExpression() ("++"|"--") )
+  PrimaryExpression()
+      ( t="++" | t="--" ) {
+        jjtThis.kind = t.kind; jjtThis.postfix = true; } #UnaryExpression(1)
+|
+  PrimaryExpression()
 }
 
 void CastExpression() #CastExpression :
 { }
 {
-  "(" Type() ")" UnaryExpression()
+  LOOKAHEAD( "(" PrimitiveType() ) "(" Type() ")" UnaryExpression()
+|
+  "(" Type() ")" UnaryExpressionNotPlusMinus()
 }
 
 void PrimaryExpression() #PrimaryExpression : { }

--- a/src/test/java/bsh/OperatorPrecedenceTest.java
+++ b/src/test/java/bsh/OperatorPrecedenceTest.java
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+/****************************************************************************/
+
+package bsh;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Check that the order of operator evaluation is identical to Java.
+ */
+public class OperatorPrecedenceTest {
+
+   private Interpreter i = new Interpreter();
+   
+    @Test
+    public void issue_568() throws Exception {
+
+       // Issue #568
+       assertEquals("true || false ? \"True\" : \"False\"", i.eval("true || false ? \"True\" : \"False\""), true || false ? "True" : "False");
+    }
+
+    @Test
+    public void issue_590() throws Exception {
+
+       // Issue #590
+       assertEquals("1000+60*0", i.eval("1000+60*0"), 1000+60*0);
+    }
+
+    @Test
+    public void precedence_tests() throws Exception {
+
+       assertEquals("1+1", i.eval("1+1"), 1+1);
+
+       assertEquals("false?true?1:2:false?3:4", i.eval("false?true?1:2:false?3:4"), false?true?1:2:false?3:4);
+
+       assertEquals("true||false&&false||false", i.eval("true||false&&false||false"), true||false&&false||false);
+       assertEquals("true||false&&false||false?1:2", i.eval("true||false&&false||false?1:2"), true||false&&false||false?1:2);
+       assertEquals("1==0||false&&false||false?1:2", i.eval("1==0||false&&false||false?1:2"), 1==0||false&&false||false?1:2);
+       assertEquals("1==1||false&&false||false?1:2", i.eval("1==1||false&&false||false?1:2"), 1==1||false&&false||false?1:2);
+       assertEquals("false||1<0==false||false?1:2", i.eval("false||1<0==false||false?1:2"), false||1<0==false||false?1:2);
+       assertEquals("false||1>=0==false||false?1:2", i.eval("false||1>=0==false||false?1:2"), false||1>=0==false||false?1:2);
+       assertEquals("false||1+1==2==false||false?1:2", i.eval("false||1+1==2==false||false?1:2"), false||1+1==2==false||false?1:2);
+       assertEquals("1+2*3<<2", i.eval("1+2*3<<2"), 1+2*3<<2);
+       assertEquals("false||1+2*3<<2==28==false||false?1:2", i.eval("false||1+2*3<<2==28==false||false?1:2"), false||1+2*3<<2==28==false||false?1:2);
+       assertEquals("31/7/2", i.eval("31/7/2"), 31/7/2);
+       assertEquals("1+31/7/2*10-5", i.eval("1+31/7/2*10-5"), 1+31/7/2*10-5);
+       assertEquals("1+31/7/2*10+ -5", i.eval("1+31/7/2*10+ -5"), 1+31/7/2*10+ -5);
+       assertEquals("- - - - -5", i.eval("- - - - -5"), - - - - -5);
+       assertEquals("- + - + -5", i.eval("- + - + -5"), - + - + -5);
+       assertEquals("\"a\"+\"b\".equals(\"b\")", i.eval("\"a\"+\"b\".equals(\"b\")"), "a"+"b".equals("b"));
+    }
+}
+

--- a/src/test/java/bsh/OperatorPrecedenceTest.java
+++ b/src/test/java/bsh/OperatorPrecedenceTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 public class OperatorPrecedenceTest {
 
    private Interpreter i = new Interpreter();
-   
+
     @Test
     public void issue_568() throws Exception {
 
@@ -69,4 +69,3 @@ public class OperatorPrecedenceTest {
        assertEquals("\"a\"+\"b\".equals(\"b\")", i.eval("\"a\"+\"b\".equals(\"b\")"), "a"+"b".equals("b"));
     }
 }
-

--- a/src/test/resources/test-scripts/array2.bsh
+++ b/src/test/resources/test-scripts/array2.bsh
@@ -1,0 +1,15 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+/*
+ * test that array reference does not get confused as a cast
+ * Broken by a previous commit, fixed by PR #590
+ */
+bMinT2 = new float[2];
+mm2 = (bMinT2[0]);
+
+
+complete();
+


### PR DESCRIPTION
Here is a fix for issue #590 as well as a more complete fix for issue #568.  Both of these were caused by the operator precedence rules bring dropped in an earlier commit.

This reverts commit 8e712bad002f33e5238dd00a0cb7c2ba2760322e.

This commit also adds a few tests that operator precedence in BeanShell behaves the same as Java