### PR TITLE
Fix the JSR223 script engine

### DIFF
--- a/src/main/java/bsh/engine/ScriptContextEngineView.java
+++ b/src/main/java/bsh/engine/ScriptContextEngineView.java
@@ -111,7 +111,8 @@ public class ScriptContextEngineView implements Map<String, Object> {
 
 
     /**
-     * Set the key, value binding in the ENGINE_SCOPE of the context.
+     * Set the key, value binding in the scope where the key is found, or
+     * in the ENGINE_SCOPE if the key is not found.
      *
      * @param key   key with which the specified value is to be associated.
      * @param value value to be associated with the specified key.
@@ -130,8 +131,19 @@ public class ScriptContextEngineView implements Map<String, Object> {
      */
     @Override
     public Object put(String key, Object value) {
-        Object oldValue = context.getAttribute(key, ENGINE_SCOPE);
-        context.setAttribute(key, value, ENGINE_SCOPE);
+       /*
+        * Check the scope for this key.  If not found then set the scope to
+        * ENGINE_SCOPE
+        */
+       int scope = context.getAttributesScope(key);
+       if (scope<0)
+          scope = ENGINE_SCOPE;
+        Object oldValue = context.getAttribute(key);
+
+        /*
+         * Update the value in the correct scope
+         */
+        context.setAttribute(key, value, scope);
         return oldValue;
     }
 

--- a/src/test/java/bsh/TestBshScriptEngine.java
+++ b/src/test/java/bsh/TestBshScriptEngine.java
@@ -91,7 +91,7 @@ public class TestBshScriptEngine {
         engine.eval("e=\"hello\"");
         assertEquals("hello", manager.get("e"));
         assertEquals("hello", engine.eval("e"));
-        
+
         // install and invoke a method
         engine.eval("foo() { return foo+1; }");
         // invoke a method

--- a/src/test/java/bsh/TestBshScriptEngine.java
+++ b/src/test/java/bsh/TestBshScriptEngine.java
@@ -64,7 +64,9 @@ public class TestBshScriptEngine {
 
         // bsh primitives stay primitive internally
         engine.eval( "int fooInt=42" );
-        assertEquals( 42, engine.get("foo") );
+        assertEquals( 42, engine.get("fooInt") );
+        engine.eval("fooInt++");
+        assertEquals( 43, engine.get("fooInt"));
         assertSame( engine.eval("fooInt.getClass();"), Primitive.class );
         assertThat( engine.getContext().getAttribute( "fooInt", ENGINE_SCOPE ),
             instanceOf( Integer.class ) );
@@ -79,6 +81,17 @@ public class TestBshScriptEngine {
         assertEquals( "gee", engine.get("bar") );
         assertEquals( "gee", engine.eval("bar") );
 
+        // Test variables in global scope
+        manager.put("e", 44);
+        assertEquals(44, manager.get("e"));
+        assertEquals(44, engine.eval("e"));
+        engine.eval("e=45");
+        assertEquals(45, manager.get("e"));
+        assertEquals(45, engine.eval("e"));
+        engine.eval("e=\"hello\"");
+        assertEquals("hello", manager.get("e"));
+        assertEquals("hello", engine.eval("e"));
+        
         // install and invoke a method
         engine.eval("foo() { return foo+1; }");
         // invoke a method


### PR DESCRIPTION
Fix the JSR223 script engine plugin so update variables in the same scope that they are found in.  The previous version would always set variables in the ENGINE_SCOPE, thus causing global scope variables to be shadowed.

Add tests for correctness.

This PR provides a fix for issue #607.