### PR TITLE
Minor changes to allow building with JDK 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>3.0.0-M5</version>
         <configuration>
           <argLine>-XX:+UseSerialGC ${surefireArgLine}</argLine>
           <systemPropertyVariables>
@@ -256,7 +256,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
+        <version>0.8.7</version>
         <configuration>
           <skip>false</skip>
         </configuration>

--- a/src/main/java/bsh/classpath/BshClassPath.java
+++ b/src/main/java/bsh/classpath/BshClassPath.java
@@ -368,9 +368,10 @@ public class BshClassPath
         for(int i=0; i< urls.length; i++)
             try{
                 map( urls[i] );
-            } catch ( IOException e ) {
+            } catch ( Exception e ) {
                 String s = "Error constructing classpath: " +urls[i]+": "+e;
                 errorWhileMapping( s );
+                throw new RuntimeException("Failed to map class path "+i, e);
             }
     }
 

--- a/src/test/java/bsh/classpath/BshClassPathTest.java
+++ b/src/test/java/bsh/classpath/BshClassPathTest.java
@@ -240,12 +240,5 @@ public class BshClassPathTest {
         assertEquals("abc.ABC", BshClassPath.canonicalizeClassName("abc/ABC.class"));
         assertEquals("abc.ABC", BshClassPath.canonicalizeClassName("modules/some.mod/abc.ABC"));
     }
-
-   public static void main(String[] args) {
-      try {
-         new BshClassPathTest().classpath_map_filesystem_exception();
-      } catch (Exception ex) {
-      }
-   }
 }
 

--- a/src/test/java/bsh/classpath/BshClassPathTest.java
+++ b/src/test/java/bsh/classpath/BshClassPathTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
-import java.nio.file.FileSystemNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -114,9 +113,8 @@ public class BshClassPathTest {
 
     @Test
     public void classpath_map_filesystem_exception() throws Exception {
-        thrown.expect(FileSystemNotFoundException.class);
-        String unknownString = File.separator+"unknown"+File.separator+"path";
-        thrown.expectMessage(containsString(unknownString));
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage(containsString("Failed to map"));
 
         final Interpreter bsh = new Interpreter();
         ClassManagerImpl cm = (ClassManagerImpl) bsh.getNameSpace().getClassManager();
@@ -243,5 +241,11 @@ public class BshClassPathTest {
         assertEquals("abc.ABC", BshClassPath.canonicalizeClassName("modules/some.mod/abc.ABC"));
     }
 
+   public static void main(String[] args) {
+      try {
+         new BshClassPathTest().classpath_map_filesystem_exception();
+      } catch (Exception ex) {
+      }
+   }
 }
 


### PR DESCRIPTION
Update jacoco version to one that is compatible with Java 16
Paper over the change in exception thrown by one of the jdk classes related to jars, and adjust one of the tests to match

Fix for issue #616