### PR TITLE
Fix for issue #615 

### DIFF
--- a/src/main/java/bsh/Invocable.java
+++ b/src/main/java/bsh/Invocable.java
@@ -433,7 +433,7 @@ class MethodInvocable extends ExecutingInvocable {
     protected MethodHandle lookup(MethodHandle m) {
        assert(m == null);
        assert(method != null);
-       
+
         try {
            return super.lookup(getHandle(method));
         } catch (Exception e) {
@@ -468,7 +468,7 @@ class MethodInvocable extends ExecutingInvocable {
             } catch (Exception ex2) {
             }
          }
-         
+
          clz = clz.getSuperclass();
          if (clz != null) {
             try {
@@ -480,7 +480,7 @@ class MethodInvocable extends ExecutingInvocable {
       }
       throw new RuntimeException("MethodHandle lookup failed to find a "+methodName+" in "+origClz.getName());
    }
-   
+
 
     /** Pull the cascade inheritance chain for parameter collection.
      *  {@inheritDoc} */

--- a/src/test/resources/test-scripts/Data/moduleAccess.xml
+++ b/src/test/resources/test-scripts/Data/moduleAccess.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="no"?>
+
+<!DOCTYPE map
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Map Version 1.0//EN" "http://java.sun.com/products/javahelp/map_1_0.dtd">
+<map version="1.0">
+   <mapID target="book" url="UserGuide.html"/>
+   <mapID target="preface" url="Preface.html"/>
+   <mapID target="preface_about" url="pr01s01.html"/>
+   <mapID target="preface_manual" url="pr01s02.html"/>
+</map>

--- a/src/test/resources/test-scripts/moduleAccess.bsh
+++ b/src/test/resources/test-scripts/moduleAccess.bsh
@@ -1,0 +1,41 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+
+/*
+ * Project Jigsaw introduced modules and the access issues that come 
+ * with them.  Things changed again in Java 16 as strongly encapsulated
+ * internals became the default.  Interfaces can be included in a 
+ * module that is exported, but the implementation might be in a module 
+ * that is not exported.
+ *
+ * The method invocation resolution mechanism within BeanShell
+ * needs to handle these kind of cases.  This test case uses an
+ * accessible factory to get a protected implementation.
+ * Test that methods from the accessible interface can be called
+ * with a problem.
+ *
+ * This test succeeded on Java versions 8 to 15, but failed on
+ * Java 16+ without a patch to bsh/Invocable.java
+ *
+ */
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.xml.sax.InputSource;
+
+input = pathToFile(dirname(getSourceFileInfo())+File.separator+"Data/moduleAccess.xml").getPath();
+
+dbf = DocumentBuilderFactory.newInstance();
+dbf.setValidating(false);
+dbf.setNamespaceAware(true);
+dbf.setFeature("http://xml.org/sax/features/namespaces", false);
+dbf.setFeature("http://xml.org/sax/features/validation", false);
+dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
+dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+docBuilder = dbf.newDocumentBuilder();
+doc = docBuilder.parse(new InputSource(input));
+nodes = doc.getElementsByTagName("mapID");
+
+assert(nodes.getLength() == 4);
+
+complete();


### PR DESCRIPTION
Strong encapsulation in Java 16+ causes problems for MethodHandle lookups.
In case there is an AccessException when looking up a method handle this fix will continue searching up the class inheritance hierarchy to find an accessible method.