### PR TITLE
Memory leak in BSHBlock.cache fix

### DIFF
--- a/src/main/java/bsh/BSHBlock.java
+++ b/src/main/java/bsh/BSHBlock.java
@@ -43,11 +43,17 @@ class BSHBlock extends SimpleNode
     private static final ReferenceCache<NameSpace,NameSpace> blockspaces
         = new ReferenceCache<NameSpace, NameSpace>(Type.Weak, Type.Weak, 4000) {
             protected NameSpace create(NameSpace key) {
+                //System.out.print("blockspaces.size=" + blockspaces.size());
                 return new BlockNameSpace(key);
             }
     };
 
     BSHBlock(int id) { super(id); }
+
+    static void removeNamespaceFromBlockspacesCache(NameSpace ns)
+    {
+        blockspaces.remove(ns);
+    }
 
     public Object eval( CallStack callstack, Interpreter interpreter)
         throws EvalError

--- a/src/main/java/bsh/BSHBlock.java
+++ b/src/main/java/bsh/BSHBlock.java
@@ -160,6 +160,7 @@ class BSHBlock extends SimpleNode
             // make sure we put the namespace back when we leave.
             // clear cached block name space, store as empty
             if ( !overrideNamespace ) {
+                BSHBlock.removeNamespaceFromBlockspacesCache(enclosingNameSpace);
                 callstack.top().clear();
                 callstack.swap( enclosingNameSpace );
             }

--- a/src/main/java/bsh/BSHTryStatement.java
+++ b/src/main/java/bsh/BSHTryStatement.java
@@ -83,8 +83,11 @@ class BSHTryStatement extends SimpleNode
         */
         int callstackDepth = callstack.depth();
         NameSpace enclosingNameSpaceTry = null;
+        BlockNameSpace tryBlockNamespace = null;
         try {
-            enclosingNameSpaceTry = callstack.swap(new BlockNameSpace(callstack.top()));
+            tryBlockNamespace = new BlockNameSpace(callstack.top());
+            //tryBlockNamespace.setName(tryBlockNamespace.getName() + "(tryBlock)");
+            enclosingNameSpaceTry = callstack.swap(tryBlockNamespace);
             ret = tryBlock.eval(callstack, interpreter, true);
         }
         catch( TargetError e ) {

--- a/src/main/java/bsh/BSHTryStatement.java
+++ b/src/main/java/bsh/BSHTryStatement.java
@@ -82,15 +82,21 @@ class BSHTryStatement extends SimpleNode
             to exception message?
         */
         int callstackDepth = callstack.depth();
+        NameSpace enclosingNameSpaceTry = null;
         try {
-            ret = tryBlock.eval(callstack, interpreter);
+            enclosingNameSpaceTry = callstack.swap(new BlockNameSpace(callstack.top()));
+            ret = tryBlock.eval(callstack, interpreter, true);
         }
         catch( TargetError e ) {
             thrown = e.getTarget();
             // clean up call stack grown due to exception interruption
             while ( callstack.depth() > callstackDepth )
-                callstack.pop();
+                callstack.pop().clear();
         } finally {
+            // cleanup try namespace
+            callstack.top().clear();
+            callstack.swap(enclosingNameSpaceTry);
+
             // unwrap the target error
             while ( null != thrown && thrown.getCause() instanceof TargetError )
                 thrown = ((TargetError) thrown.getCause()).getTarget();

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -458,7 +458,10 @@ public class BshMethod implements Serializable {
 
         // Get back to caller namespace
         if ( !overrideNameSpace )
+        {
+            BSHBlock.removeNamespaceFromBlockspacesCache(localNameSpace);
             callstack.pop();
+        }
 
         ReturnControl retControl = null;
         if ( ret instanceof ReturnControl ) {


### PR DESCRIPTION
Suggested fix for #643 Memory leak in BSHBlock.cache in try blocks because BSHBlock.evalBlock with overrideNamespace=false creates a new BlockNamespace on blockspaces 