### PR TITLE
Block namespace methods fix.

### DIFF
--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -343,11 +343,9 @@ public class BshMethod implements Serializable {
         if ( overrideNameSpace )
             localNameSpace = callstack.top();
         else
-        {
             localNameSpace = new NameSpace( declaringNameSpace, name );
-            localNameSpace.isMethod = true;
-        }
-        // should we do this for both cases above?
+
+        localNameSpace.isMethod = true;
         localNameSpace.setNode( callerInfo );
 
         /*

--- a/src/test/resources/test-scripts/eval.bsh
+++ b/src/test/resources/test-scripts/eval.bsh
@@ -36,4 +36,15 @@ assert(b==6); // sanity check
 assert(s.a==5);
 assert(a==6);
 
+// block namespace calling method twice #508
+y = 22;
+try { eval("yval=y;"); }
+catch (e) { assert(false); }
+assert(yval==y);
+yval=0;
+try { eval("yval=y;"); }
+catch (e) { assert(false); }
+assert(yval==22);
+
+
 complete();

--- a/src/test/resources/test-scripts/run.bsh
+++ b/src/test/resources/test-scripts/run.bsh
@@ -15,6 +15,7 @@ assert( r.g == 6 );
 // Note: this could fail legitimately if we're not in the test dir...
 assert( r.cwd != void );
 assert( !r.cwd.equals( bsh.cwd) );
+assert( r.cwd.endsWith("resources") );
 
 arg = object();
 arg.foo=1;
@@ -28,6 +29,16 @@ assert( r.c == 5 );
 assert( isEvalError("new AddClass()") );
 // should show no class loading...
 //this.namespace.getClassManager().dump( new PrintWriter(System.out,true));
+
+// block namespace calling method twice #508
+try {
+    r = run("Data/run_aux.bsh");
+    assert( r.cwd.endsWith("resources") );
+} catch (e) { assert(false); }
+try {
+    r = run("Data/run_aux.bsh");
+    assert( r.cwd.endsWith("resources") );
+} catch (e) { assert(false); }
 
 complete();
 


### PR DESCRIPTION
Fixes #508
Override namespace looses its local namespace  flag, causing duplicate blocked methods to fail on subsequent calls.
Added unit tests to prove fixes.