### PR TITLE
Adjust BSHArrayDimensions to allow that boxed integral values

### DIFF
--- a/src/main/java/bsh/BSHArrayDimensions.java
+++ b/src/main/java/bsh/BSHArrayDimensions.java
@@ -117,7 +117,15 @@ class BSHArrayDimensions extends SimpleNode
             {
                 try {
                     Object length = jjtGetChild(i).eval(callstack, interpreter);
-                    definedDimensions[i] = ((Primitive)length).intValue();
+                    // Expect this to be a primitive, but also unbox numbers
+                    int dim;
+                    if (length instanceof Integer ||
+                        length instanceof Short ||
+                        length instanceof Byte)
+                       dim = ((Number)length).intValue();
+                    else
+                       dim = ((Primitive)length).intValue();
+                    definedDimensions[i] = dim;
                 }
                 catch(Exception e)
                 {

--- a/src/test/resources/test-scripts/arraydims.bsh
+++ b/src/test/resources/test-scripts/arraydims.bsh
@@ -151,4 +151,9 @@ String[][] array2dim1 = new String[10][];
 int[][][] primi3 = new int [3][][];
 assert( primi3 instanceof int[][][] );
 
+// Assert that reference objects in array dimensions can be unboxed and widened
+assert(new int[Integer.valueOf(3)].length == 3);
+assert(new int[Byte.valueOf((byte)3)].length == 3);
+assert(new int[Short.valueOf((short)3)].length == 3);
+
 complete();


### PR DESCRIPTION
 (Integer, Short and Byte) can be used to specify sizes in array dimensions.
 Add a test of creating arrays using boxed values in the array dimensions.

 tmoore <tmoore@spatial.ca>