### PR TITLE
All number types for array arguments.

### DIFF
--- a/src/main/java/bsh/BSHArrayDimensions.java
+++ b/src/main/java/bsh/BSHArrayDimensions.java
@@ -117,13 +117,13 @@ class BSHArrayDimensions extends SimpleNode
             {
                 try {
                     Object length = jjtGetChild(i).eval(callstack, interpreter);
-                    definedDimensions[i] = ((Primitive)length).intValue();
+                    definedDimensions[i] = (int) Primitive.castWrapper(Integer.TYPE, length);
                 }
                 catch(Exception e)
                 {
                     throw new EvalError(
                         "Array index: " + i +
-                        " does not evaluate to an integer", this, callstack );
+                        " length does not evaluate to an integer", this, callstack, e );
                 }
             }
         }

--- a/src/main/java/bsh/BSHPrimarySuffix.java
+++ b/src/main/java/bsh/BSHPrimarySuffix.java
@@ -277,8 +277,9 @@ class BSHPrimarySuffix extends SimpleNode
                 && Types.isPropertyTypeEntryList(cls) ) {
             Object key = jjtGetChild(0).eval(callstack, interpreter);
             int idx = 0;
-            if ( key instanceof Primitive && ((Primitive) key).isNumber()
-                    && length > (idx = ((Primitive) key).intValue())
+            if ( ((key instanceof Primitive && ((Primitive) key).isNumber())
+                        || Primitive.isWrapperType(key.getClass()))
+                    && length > (idx = (int) Primitive.castWrapper(Integer.TYPE, key))
                     && -length < idx)
                 index = idx;
             else if (toLHS)

--- a/src/main/java/bsh/BSHPrimarySuffix.java
+++ b/src/main/java/bsh/BSHPrimarySuffix.java
@@ -221,12 +221,12 @@ class BSHPrimarySuffix extends SimpleNode
             if ( !(indexVal instanceof Primitive) )
                 indexVal = Types.castObject(
                     indexVal, Integer.TYPE, Types.ASSIGNMENT );
-            index = ((Primitive) indexVal).intValue();
-        } catch( UtilEvalError e ) {
+            index = (int) Primitive.castWrapper(Integer.TYPE, indexVal);
+        } catch( Exception e ) {
             Interpreter.debug("doIndex: "+e);
-            throw e.toEvalError(
-                "Arrays may only be indexed by integer types.",
-                callerInfo, callstack );
+            throw new EvalError(
+                "Array index does not evaluate to an integer.",
+                callerInfo, callstack, e);
         }
         return index;
     }
@@ -278,7 +278,7 @@ class BSHPrimarySuffix extends SimpleNode
             Object key = jjtGetChild(0).eval(callstack, interpreter);
             int idx = 0;
             if ( key instanceof Primitive && ((Primitive) key).isNumber()
-                    && length > (idx = ((Primitive) key).numberValue().intValue())
+                    && length > (idx = ((Primitive) key).intValue())
                     && -length < idx)
                 index = idx;
             else if (toLHS)

--- a/src/main/java/bsh/BshArray.java
+++ b/src/main/java/bsh/BshArray.java
@@ -1,3 +1,17 @@
+
+/** Copyright 2018 Nick nickl- Lombard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
 package bsh;
 
 import java.lang.reflect.Array;

--- a/src/main/java/bsh/Primitive.java
+++ b/src/main/java/bsh/Primitive.java
@@ -203,11 +203,9 @@ public final class Primitive implements Serializable {
     }
 
 
-    public int intValue() throws UtilEvalError
+    public int intValue()
     {
-        if(value instanceof Number)
-            return((Number)value).intValue();
-        throw new UtilEvalError("Primitive not a number");
+        return (int) castNumber(Integer.TYPE, numberValue());
     }
 
     public boolean booleanValue() throws UtilEvalError
@@ -391,7 +389,7 @@ public final class Primitive implements Serializable {
     public static Class<?> boxType( Class<?> primitiveType )
     {
         Class<?> c = wrapperMap.get( primitiveType );
-        if ( c != null )
+        if ( c != null && !c.isPrimitive() )
             return c;
         throw new InterpreterError(
             "Not a primitive type: "+ primitiveType );
@@ -405,7 +403,7 @@ public final class Primitive implements Serializable {
     public static Class<?> unboxType( Class<?> wrapperType )
     {
         Class<?> c = wrapperMap.get( wrapperType );
-        if ( c != null )
+        if ( c != null && (c.isPrimitive() || c == wrapperType) )
             return c;
         throw new InterpreterError(
             "Not a primitive wrapper type: "+wrapperType );
@@ -571,6 +569,8 @@ public final class Primitive implements Serializable {
     }
 
     static Object castNumber(Class<?> toType, Number number) {
+        if (toType == number.getClass() || toType == unboxType(number.getClass()))
+            return number;
         if ((toType == Byte.class || toType == Byte.TYPE)
                 && number.shortValue() <= 0xff && number.shortValue() >= Byte.MIN_VALUE)
             return number.byteValue();

--- a/src/main/java/bsh/Primitive.java
+++ b/src/main/java/bsh/Primitive.java
@@ -608,8 +608,6 @@ public final class Primitive implements Serializable {
             if (toType == BigDecimal.class)
                 return BigDecimal.ONE.setScale(1);
         } else if (toType == BigDecimal.class) {
-            if ( number instanceof BigDecimal )
-                return (BigDecimal) number;
             if ( number instanceof BigInteger )
                 return new BigDecimal((BigInteger) number).setScale(1);
             if ( Types.isFloatingpoint(number) )

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -759,7 +759,7 @@ public final class Reflect {
     @SuppressWarnings("rawtypes")
     public static Entry getEntryForKey(Object key, Entry[] entries) {
         for ( Entry ntre : entries )
-            if ( null != ntre && key.equals(ntre.getKey()) )
+            if ( key.equals(ntre.getKey()) )
                 return ntre;
         throw new ReflectError("No such property: " + key);
     }

--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -619,9 +619,7 @@ class Types {
             {
                 // primitive to wrapper type
                 return checkOnly ? VALID_CAST :
-                    Primitive.castWrapper(
-                        Primitive.unboxType(toType),
-                        ((Primitive)fromValue).getValue() );
+                    Primitive.castWrapper(Primitive.unboxType(toType), fromValue);
             }
 
             // Primitive (not null or void) to Object.class type
@@ -629,8 +627,7 @@ class Types {
                 && fromType != Void.TYPE && fromType != null )
             {
                 // box it
-                return checkOnly ? VALID_CAST :
-                    ((Primitive)fromValue).getValue();
+                return checkOnly ? VALID_CAST : Primitive.unwrap(fromValue);
             }
 
             // Primitive to arbitrary object type.

--- a/src/test/java/bsh/TypesTest.java
+++ b/src/test/java/bsh/TypesTest.java
@@ -1,0 +1,84 @@
+/** Copyright 2022 Nick nickl- Lombard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+
+package bsh;
+
+import java.math.BigInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TypesTest {
+
+    /**
+     * Test cast primitive to wrapper type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_object_primitive_to_wrapper_type() throws Exception {
+        Object casted = Types.castObject(Primitive.wrap(1, Integer.TYPE), Integer.class, Types.CAST);
+
+        Assert.assertEquals(Integer.valueOf(1), casted);
+    }
+
+    /**
+     * Test can cast primitive to wrapper type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void can_cast_object_primitive_to_wrapper_type() throws Exception {
+        Assert.assertTrue(Types.isBshAssignable(Integer.class, Integer.TYPE));
+    }
+
+    /**
+     * Test cast primitive to wrapper type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_object_primitive_big_integer_to_long_type() throws Exception {
+        Object casted = Types.castObject(Primitive.wrap(BigInteger.valueOf(3L), BigInteger.class), Long.class, Types.CAST);
+
+        Assert.assertEquals(Long.valueOf(3), casted);
+    }
+
+    /**
+     * Test can cast primitive to wrapper type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void can_cast_object_primitive_big_integer_to_long_type() throws Exception {
+        Assert.assertTrue(Types.isBshAssignable(Long.class, BigInteger.class));
+    }
+
+    /**
+     * Test cast primitive to object
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_object_primitive_to_object() throws Exception {
+        Object casted = Types.castObject(Primitive.wrap(1, Integer.TYPE), Object.class, Types.CAST);
+
+        Assert.assertEquals((Object)Integer.valueOf(1), casted);
+    }
+
+    /**
+     * Test can cast primitive to object
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void can_cast_object_primitive_to_object() throws Exception {
+        Assert.assertTrue(Types.isBshAssignable(Object.class, Integer.TYPE));
+    }
+
+}

--- a/src/test/resources/test-scripts/TestHarness.bsh
+++ b/src/test/resources/test-scripts/TestHarness.bsh
@@ -28,9 +28,14 @@ isEvalError( String... text )
         // eval in the namespace of whomever sourced this file.
         this.interpreter.eval( text[idx], this.caller.namespace );
     } catch ( bsh.EvalError e ) {
-        if ( idx > 0 && !e.getMessage().contains(text[0]) ) {
+        if ( idx > 0 && null != e.getCause() && null != e.getCause().getMessage()
+                && e.getCause().getMessage().contains(text[0]))
+            flag = true;
+        else if ( idx > 0 && !e.getMessage().contains(text[0])) {
             super.test_message = "\nExpected message: "+text[0]
-                    +"\nbut found: "+e.getMessage() + ".\n";
+                    +"\nbut found: "+e.getMessage() + "\n";
+            if (null != e.getCause() && null != e.getCause().getMessage())
+                super.test_message += "Caused by: " + e.getCause().getMessage() + "\n";
             super.test_failed = true;
         } else
             flag = true;

--- a/src/test/resources/test-scripts/arraydims.bsh
+++ b/src/test/resources/test-scripts/arraydims.bsh
@@ -1,6 +1,7 @@
 #!/bin/java bsh.Interpreter
 
 source("TestHarness.bsh");
+source("Assert.bsh");
 
 oa = new Object [] { "foo", "bar" };
 assert( oa.length == 2 && oa[0] instanceof String );
@@ -150,5 +151,25 @@ String[][] array2dim1 = new String[10][];
 
 int[][][] primi3 = new int [3][][];
 assert( primi3 instanceof int[][][] );
+
+// Verify array dimensions set by various number types
+assertArrayEquals({0, 0, 0}, new int[Integer.valueOf(3i)]);
+assertArrayEquals({0, 0, 0}, new int[Byte.valueOf(3o)]);
+assertArrayEquals({0, 0, 0}, new int[Short.valueOf(3s)]);
+assertArrayEquals({0, 0, 0}, new int[Float.valueOf(3.0f)]);
+assertArrayEquals({0, 0, 0}, new int[Double.valueOf(3.0d)]);
+assertArrayEquals({0, 0, 0}, new int[3i]);
+assertArrayEquals({0, 0, 0}, new int[3o]);
+assertArrayEquals({0, 0, 0}, new int[3s]);
+assertArrayEquals({0, 0, 0}, new int[3.0f]);
+assertArrayEquals({0, 0, 0}, new int[3.0d]);
+assertArrayEquals({0, 0, 0}, new int[3w]);
+assertArrayEquals({0, 0, 0}, new int[3.0w]);
+
+// Verify overflow protection of narrowed types
+assert(isEvalError("cannot assign number 2147483648 to type int", 'new int[2147483648];'));
+assert(isEvalError("cannot assign number 2147483648 to type int", 'new int[2147483648l];'));
+assert(isEvalError("cannot assign number 2147483648 to type int", 'new int[2147483648w];'));
+assert(isEvalError("cannot assign number 2147483648.0 to type int", 'new int[2147483648.0w];'));
 
 complete();

--- a/src/test/resources/test-scripts/bean_properties.bsh
+++ b/src/test/resources/test-scripts/bean_properties.bsh
@@ -47,6 +47,9 @@ obj = new TestClass();
 assert(isEvalError("No such property: instVar", 'obj.instVar = 434;'));
 assertTrue(obj.instVar == void);
 // instance bean accessor methods
+assertThat(obj.instProp, equalTo(0));
+assertThat(obj.statProp, equalTo(0));
+assertThat(obj.statBoolProp, equalTo(false));
 obj.setInstProp(111);
 assertThat(obj.getInstProp(), equalTo(111));
 obj.setInstBoolProp(true);

--- a/src/test/resources/test-scripts/expression_array.bsh
+++ b/src/test/resources/test-scripts/expression_array.bsh
@@ -331,7 +331,7 @@ assert(isEvalError("Error array get index: Index 3 out-of-bounds for length 2", 
 assert(isEvalError("Error array get index: Index 3 out-of-bounds for length 2", "((List) {1,2})[3];"));
 assert(isEvalError("Not an array or List type", "''[1];"));
 assert(isEvalError("Class: Unknow.ObjectType not found in namespace", "new Unknow.ObjectType[0];"));
-assert(isEvalError("Array index: 0 does not evaluate to an integer", 'new int["0"];'));
+assert(isEvalError("Array index: 0 length does not evaluate to an integer", 'new int["0"];'));
 assert(isEvalError("Incompatible initializer. Allocation calls for a 2 dimensional array, but initializer is a 1 dimensional array", "new int[][] {};"));
 assert(isEvalError("Incompatible type: boolean in initializer of array type: boolean", "new {{false}, true};"));
 assert(isEvalError("Incompatible type: Object[] in initializer of array type: Object at position: 1", "new {{{new Object()}}, new {new Object()}};"));

--- a/src/test/resources/test-scripts/expression_entry.bsh
+++ b/src/test/resources/test-scripts/expression_entry.bsh
@@ -154,6 +154,29 @@ entries = {new Entry {"k"=3}, {6}, new Entry {"l"=5}};
 assertThat(entries, valueString('{{"k"=3I}, {6I}, {"l"=5I}}'));
 assertThat(entries, instanceOf(Object[].class));
 
+// entry array index by various number types
+entries = new Entry {"k"=3, "l"=5, "m"=null};
+assertThat(entries[Integer.valueOf(0i)], valueString('"k"=3I'));
+assertThat(entries[Byte.valueOf(0o)], valueString('"k"=3I'));
+assertThat(entries[Short.valueOf(0s)], valueString('"k"=3I'));
+assertThat(entries[Float.valueOf(0.0f)], valueString('"k"=3I'));
+assertThat(entries[Double.valueOf(0.0d)], valueString('"k"=3I'));
+assertThat(entries[0i], valueString('"k"=3I'));
+assertThat(entries[0o], valueString('"k"=3I'));
+assertThat(entries[0s], valueString('"k"=3I'));
+assertThat(entries[0.0f], valueString('"k"=3I'));
+assertThat(entries[0.0d], valueString('"k"=3I'));
+assertThat(entries[0w], valueString('"k"=3I'));
+assertThat(entries[0.0w], valueString('"k"=3I'));
+assertNull(entries["m"]);
+assertNull(entries["m"] = 4);
+assertNotNull(entries["m"]);
+assertEquals(4, entries["m"]);
+assertEquals(3, entries.length);
+assert(isEvalError("cannot assign number 2147483648 to type int", "entries[2147483648]"));
+assert(isEvalError("No such property: xx", "entries['xx']"));
+assert(isEvalError("No such property: 5", "entries[5]"));
+assert(isEvalError("No such property: -5", "entries[-5]"));
 
 // nested entry arrays
 entries = new Entry {"k"=3};

--- a/src/test/resources/test-scripts/expression_map.bsh
+++ b/src/test/resources/test-scripts/expression_map.bsh
@@ -263,7 +263,6 @@ for ( a:3 ) {
 }
 assertThat(alist, valueString('[{"key"={"id"=0I}}, {"key"={"id"=1I}}, {"key"={"id"=2I}}, {"key"={"id"=3I}}]'));
 
-assert(isEvalError("Arrays may only be indexed by integer types.", '{1,2}["1"];'));
 assert(isEvalError("Can't assign array length", "{1,2,3}.length=1;"));
 assert(isEvalError("Attempt to use .class suffix on non class.", "''.class;"));
 assert(isEvalError("Can't assign .class", "Object.class=1;"));

--- a/src/test/resources/test-scripts/expression_slice.bsh
+++ b/src/test/resources/test-scripts/expression_slice.bsh
@@ -17,6 +17,36 @@ arr[-4] = 99;
 assertThat(arr[-4], equalTo(99));
 arr[-4] = 6;
 
+// array index by various number types
+assertEquals(1, arr[Integer.valueOf(1i)]);
+assertEquals(1, arr[Byte.valueOf(1o)]);
+assertEquals(1, arr[Short.valueOf(1s)]);
+assertEquals(1, arr[Float.valueOf(1.0f)]);
+assertEquals(1, arr[Double.valueOf(1.0d)]);
+assertEquals(1, arr[1i]);
+assertEquals(1, arr[1o]);
+assertEquals(9, arr[-1o]);
+assertEquals(1, arr[1s]);
+assertEquals(1, arr[1.0f]);
+assertEquals(1, arr[1.0d]);
+assertEquals(1, arr[1w]);
+assertEquals(1, arr[1.0w]);
+
+// slice by various number types
+assertArrayEquals(new Integer {0, 1}, arr[Integer.valueOf(0i):Integer.valueOf(2i):Integer.valueOf(1i)]);
+assertArrayEquals(new Integer {0, 1}, arr[Byte.valueOf(0o):Byte.valueOf(2o):Byte.valueOf(1o)]);
+assertArrayEquals(new Integer {0, 1}, arr[Short.valueOf(0s):Short.valueOf(2s):Short.valueOf(1s)]);
+assertArrayEquals(new Integer {0, 1}, arr[Float.valueOf(0.0f):Float.valueOf(2.0f):Float.valueOf(1.0f)]);
+assertArrayEquals(new Integer {0, 1}, arr[Double.valueOf(0.0d):Double.valueOf(2.0d):Double.valueOf(1.0d)]);
+assertArrayEquals(new Integer {0, 1}, arr[0i:2i:1i]);
+assertArrayEquals(new Integer {0, 1}, arr[0o:2o:1o]);
+assertArrayEquals(new Integer {0, 1}, arr[0o:2s:1i]);
+assertArrayEquals(new Integer {0, 1}, arr[0s:2s:1s]);
+assertArrayEquals(new Integer {0, 1}, arr[0.0f:2.0f:1.0f]);
+assertArrayEquals(new Integer {0, 1}, arr[0.0d:2.0d:1.0d]);
+assertArrayEquals(new Integer {0, 1}, arr[0w:2w:1w]);
+assertArrayEquals(new Integer {0, 1}, arr[0.0w:2.0w:1.0w]);
+
 // array range slice
 slice = arr[0:];
 assertThat(slice, valueString('{0I, 1I, 2I, 3I, 4I, 5I, 6I, 7I, 8I, 9I}'));
@@ -265,6 +295,20 @@ list[-4] = 99;
 assertThat(list[-4], equalTo(99));
 list[-4] = 6;
 
+// list index by various number types
+assertEquals(1, list[Integer.valueOf(1i)]);
+assertEquals(1, list[Byte.valueOf(1o)]);
+assertEquals(1, list[Short.valueOf(1s)]);
+assertEquals(1, list[Float.valueOf(1.0f)]);
+assertEquals(1, list[Double.valueOf(1.0d)]);
+assertEquals(1, list[1i]);
+assertEquals(1, list[1o]);
+assertEquals(1, list[1s]);
+assertEquals(1, list[1.0f]);
+assertEquals(1, list[1.0d]);
+assertEquals(1, list[1w]);
+assertEquals(1, list[1.0w]);
+
 // list range slice
 slice = list[0:];
 assertThat(slice, valueString('[0I, 1I, 2I, 3I, 4I, 5I, 6I, 7I, 8I, 9I]'));
@@ -449,6 +493,20 @@ assertThat(queue[-4], equalTo(6));
 queue[-4] = 99;
 assertThat(queue[-4], equalTo(99));
 queue[-4] = 6;
+
+// queue index by various number types
+assertEquals(1, queue[Integer.valueOf(1i)]);
+assertEquals(1, queue[Byte.valueOf(1o)]);
+assertEquals(1, queue[Short.valueOf(1s)]);
+assertEquals(1, queue[Float.valueOf(1.0f)]);
+assertEquals(1, queue[Double.valueOf(1.0d)]);
+assertEquals(1, queue[1i]);
+assertEquals(1, queue[1o]);
+assertEquals(1, queue[1s]);
+assertEquals(1, queue[1.0f]);
+assertEquals(1, queue[1.0d]);
+assertEquals(1, queue[1w]);
+assertEquals(1, queue[1.0w]);
 
 // queue range slice
 slice = queue[0::];
@@ -695,6 +753,15 @@ list[1::2][1:2].clear();
 assertThat(list[::1], contains(0, 1, 2, 4, 5, 6, 7, 8, 9));
 
 // slice exceptions
+assert(isEvalError("cannot assign number 2147483648 to type int", '{1,2}[2147483648];'));
+assert(isEvalError("cannot assign number 2147483648 to type int", '{1,2}[2147483648l];'));
+assert(isEvalError("cannot assign number 2147483648 to type int", '{1,2}[2147483648w];'));
+assert(isEvalError("cannot assign number 2147483648.0 to type int", '{1,2}[2147483648.0w];'));
+assert(isEvalError("cannot assign number 2147483648 to type int", '{1,2}[2147483648:];'));
+assert(isEvalError("cannot assign number 2147483648 to type int", '{1,2}[2147483648l:];'));
+assert(isEvalError("cannot assign number 2147483648 to type int", '{1,2}[2147483648w:];'));
+assert(isEvalError("cannot assign number 2147483648.0 to type int", '{1,2}[2147483648.0w:];'));
+assert(isEvalError("Array index does not evaluate to an integer.", '{1,2}["1"];'));
 assert(isEvalError('Use of invalid operator "/" with array', "arr /= 3;"));
 assert(isEvalError("cannot assign to array slice", "{1,2}[0:1] = 1;"));
 assert(isEvalError("array slice step cannot be zero", "{1,2}[::0];"));

--- a/src/test/resources/test-scripts/primitives_assignment.bsh
+++ b/src/test/resources/test-scripts/primitives_assignment.bsh
@@ -559,7 +559,12 @@ assertFalse(Primitive.isWrapperType(null));
 
 assertFalse(void.isNumber());
 
+assertEquals(1i, Primitive.wrap(1l, Long.TYPE).intValue());
 assertEquals(Integer.class, Primitive.boxType(Integer.TYPE));
+assertEquals(Integer.TYPE, Primitive.unboxType(Integer.class));
+assertEquals(BigDecimal.class, Primitive.unboxType(BigDecimal.class));
+assert(isEvalError("Not a primitive type: class java.lang.Integer", "Primitive.boxType(Integer.class);"));
+assert(isEvalError("Not a primitive wrapper type: int", "Primitive.unboxType(Integer.TYPE);"));
 assertEquals(0, a.hashCode());
 assertFalse(void.equals(1));
 assertEquals("void", void.toString());


### PR DESCRIPTION
Array dimensions accept all number types
Array indexes accept all number types
Array slices accept all number types
List dimensions accept all number types
List indexes accept all number types
List slices accept all number types
Entry array indexes accept all number types
Improve exception messages and add cause.
Improve assert for error message to include cause. Improve Primitive intValue to also cast for value. Added quick exit condition for cast to existing type. Added precision to Primitive boxType and unboxType. Optimize Types use of Primitive wrap and unwrap.
Added extensive unit tests for all number types.

Fixes #652 and #658