### PR TITLE
Fixes and improvements to reference cache.

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-#Tue Jun 18 02:45:37 GMT+02:00 2019
+#Project version number - populated by maven
+#Project build number - incremented by beanshell-maven-plugin
+#Thu Dec 08 16:32:51 SAST 2022
+build=936
 release=${project.version}
-build=842

--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,4 +14,4 @@
 #
 #Tue Jun 18 02:45:37 GMT+02:00 2019
 release=${project.version}
-build=841
+build=842

--- a/src/main/java/bsh/BSHAllocationExpression.java
+++ b/src/main/java/bsh/BSHAllocationExpression.java
@@ -31,6 +31,7 @@ package bsh;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.concurrent.CompletionException;
 
 /**
     New object, new array, or inner class style allocation with body.
@@ -152,7 +153,7 @@ class BSHAllocationExpression extends SimpleNode
         } catch ( ReflectError e) {
             throw new EvalError(
                 "Constructor error: " + e.getMessage(), this, callstack, e);
-        } catch (InvocationTargetException e) {
+        } catch (InvocationTargetException | CompletionException e) {
             // No need to wrap this debug
             Interpreter.debug("The constructor threw an exception:\n\t"
                     + e.getCause());

--- a/src/main/java/bsh/BSHAmbiguousName.java
+++ b/src/main/java/bsh/BSHAmbiguousName.java
@@ -93,7 +93,7 @@ class BSHAmbiguousName extends SimpleNode
     }
 
     public String toString() {
-        return "AmbigousName: "+text;
+        return super.toString() + ": " + text;
     }
 }
 

--- a/src/main/java/bsh/BSHArrayDimensions.java
+++ b/src/main/java/bsh/BSHArrayDimensions.java
@@ -130,4 +130,9 @@ class BSHArrayDimensions extends SimpleNode
 
         return Primitive.VOID;
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": " + numDefinedDims + ", " + numUndefinedDims;
+    }
 }

--- a/src/main/java/bsh/BSHArrayInitializer.java
+++ b/src/main/java/bsh/BSHArrayInitializer.java
@@ -338,4 +338,9 @@ class BSHArrayInitializer extends SimpleNode {
             +" in initializer of array type: "+ baseType.getSimpleName()
             +" at position: "+argNum, this, callstack );
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": " + isMapInArray;
+    }
 }

--- a/src/main/java/bsh/BSHBlock.java
+++ b/src/main/java/bsh/BSHBlock.java
@@ -166,5 +166,9 @@ class BSHBlock extends SimpleNode
         boolean isVisible( Node node );
     }
 
+    @Override
+    public String toString() {
+        return super.toString() + ": static=" + isStatic + ", synchronized=" + isSynchronized;
+    }
 }
 

--- a/src/main/java/bsh/BSHClassDeclaration.java
+++ b/src/main/java/bsh/BSHClassDeclaration.java
@@ -115,6 +115,6 @@ class BSHClassDeclaration extends SimpleNode
     }
 
     public String toString() {
-        return "ClassDeclaration: " + name;
+        return super.toString() + ": " + name;
     }
 }

--- a/src/main/java/bsh/BSHEnhancedForStatement.java
+++ b/src/main/java/bsh/BSHEnhancedForStatement.java
@@ -113,4 +113,8 @@ class BSHEnhancedForStatement extends SimpleNode implements ParserConstants {
         return returnControl;
     }
 
+    @Override
+    public String toString() {
+        return super.toString() + ": " + varName + ", final=" + isFinal;
+    }
 }

--- a/src/main/java/bsh/BSHEnumConstant.java
+++ b/src/main/java/bsh/BSHEnumConstant.java
@@ -63,8 +63,7 @@ public class BSHEnumConstant extends SimpleNode {
     }
 
     public String toString() {
-        return "EnumConstant: "+mods+" "+getType()+" "+name;
+        return super.toString() + ": " + mods + " " + getType() + " " + name;
     }
-
 }
 /* JavaCC - OriginalChecksum=6bf5bca59c6d351657103c4ff0e8d054 (do not edit this line) */

--- a/src/main/java/bsh/BSHForStatement.java
+++ b/src/main/java/bsh/BSHForStatement.java
@@ -132,4 +132,8 @@ class BSHForStatement extends SimpleNode implements ParserConstants
         return returnControl;
     }
 
+    @Override
+    public String toString() {
+        return super.toString() + ": " + hasForInit + " ; " + hasExpression + " ; " + hasForUpdate;
+    }
 }

--- a/src/main/java/bsh/BSHFormalComment.java
+++ b/src/main/java/bsh/BSHFormalComment.java
@@ -35,4 +35,8 @@ public class BSHFormalComment extends SimpleNode
         super(id);
     }
 
+    @Override
+    public String toString() {
+        return super.toString() + ": " + text;
+    }
 }

--- a/src/main/java/bsh/BSHFormalParameter.java
+++ b/src/main/java/bsh/BSHFormalParameter.java
@@ -71,5 +71,10 @@ class BSHFormalParameter extends SimpleNode
 
         return type;
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": " + name + ", final=" + isFinal + ", varargs=" + isVarArgs;
+    }
 }
 

--- a/src/main/java/bsh/BSHImportDeclaration.java
+++ b/src/main/java/bsh/BSHImportDeclaration.java
@@ -97,5 +97,10 @@ class BSHImportDeclaration extends SimpleNode
         }
         return Primitive.VOID;
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": static=" + staticImport + ", *=" + importPackage + ", super import=" + superImport;
+    }
 }
 

--- a/src/main/java/bsh/BSHMethodDeclaration.java
+++ b/src/main/java/bsh/BSHMethodDeclaration.java
@@ -168,6 +168,6 @@ class BSHMethodDeclaration extends SimpleNode
     }
 
     public String toString() {
-        return "MethodDeclaration: "+name;
+        return super.toString() + ": " + name;
     }
 }

--- a/src/main/java/bsh/BSHMultiCatch.java
+++ b/src/main/java/bsh/BSHMultiCatch.java
@@ -58,5 +58,10 @@ public class BSHMultiCatch extends SimpleNode {
     public Class<?>[] getTypes() {
         return this.types;
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": " + name + ", final=" + isFinal;
+    }
 }
 /* JavaCC - OriginalChecksum=cc337eefa5f343b6ba168cc49758c10a (do not edit this line) */

--- a/src/main/java/bsh/BSHPrimarySuffix.java
+++ b/src/main/java/bsh/BSHPrimarySuffix.java
@@ -380,5 +380,18 @@ class BSHPrimarySuffix extends SimpleNode
             throw new EvalError("No such property: " + value, this, callstack, e);
         }
     }
+
+    @Override
+    public String toString() {
+        if (operation == INDEX)
+            return super.toString() + ": [" + hasLeftIndex + ":" + slice + " " + hasRightIndex + ":" + step + "]";
+        if (operation == NAME)
+            return super.toString() + ": " + field;
+        if (operation == PROPERTY)
+            return super.toString() + ": {}";
+        if (operation == NEW)
+            return super.toString() + ": new";
+        return super.toString() + ": class"; // CLASS == 0
+    }
 }
 

--- a/src/main/java/bsh/BSHPrimitiveType.java
+++ b/src/main/java/bsh/BSHPrimitiveType.java
@@ -34,5 +34,10 @@ class BSHPrimitiveType extends SimpleNode
 
     BSHPrimitiveType(int id) { super(id); }
     public Class getType() { return type; }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": " + type;
+    }
 }
 

--- a/src/main/java/bsh/BSHReturnStatement.java
+++ b/src/main/java/bsh/BSHReturnStatement.java
@@ -45,5 +45,9 @@ class BSHReturnStatement extends SimpleNode implements ParserConstants
 
         return new ReturnControl( kind, value, this );
     }
-}
 
+    @Override
+    public String toString() {
+        return super.toString() + ": " + tokenImage[kind];
+    }
+}

--- a/src/main/java/bsh/BSHReturnType.java
+++ b/src/main/java/bsh/BSHReturnType.java
@@ -56,5 +56,9 @@ class BSHReturnType extends SimpleNode
         else
             return getTypeNode().getType( callstack, interpreter );
     }
-}
 
+    @Override
+    public String toString() {
+        return super.toString() + ": void=" + isVoid;
+    }
+}

--- a/src/main/java/bsh/BSHSwitchLabel.java
+++ b/src/main/java/bsh/BSHSwitchLabel.java
@@ -37,4 +37,9 @@ class BSHSwitchLabel extends SimpleNode {
     {
         return jjtGetChild(0).eval( callstack, interpreter );
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": " + (isDefault ? "default" : "case");
+    }
 }

--- a/src/main/java/bsh/BSHTypedVariableDeclaration.java
+++ b/src/main/java/bsh/BSHTypedVariableDeclaration.java
@@ -118,4 +118,7 @@ class BSHTypedVariableDeclaration extends SimpleNode {
         return value;
     }
 
+    public String toString() {
+        return super.toString() + ": " + modifiers;
+    }
 }

--- a/src/main/java/bsh/BSHVariableDeclarator.java
+++ b/src/main/java/bsh/BSHVariableDeclarator.java
@@ -93,5 +93,9 @@ class BSHVariableDeclarator extends SimpleNode
             return typeNode.getArrayDims();
         return -1;
     }
-    public String toString() { return "BSHVariableDeclarator "+name; }
+
+    @Override
+    public String toString() {
+        return super.toString() + ": " + name;
+    }
 }

--- a/src/main/java/bsh/BSHWhileStatement.java
+++ b/src/main/java/bsh/BSHWhileStatement.java
@@ -85,4 +85,8 @@ class BSHWhileStatement extends SimpleNode implements ParserConstants {
         return Primitive.VOID;
     }
 
+    @Override
+    public String toString() {
+        return super.toString() + ": do=" + isDoStatement;
+    }
 }

--- a/src/main/java/bsh/Name.java
+++ b/src/main/java/bsh/Name.java
@@ -1020,8 +1020,12 @@ class Name implements java.io.Serializable
             return suffix[parts];
         }
         public static Parts get(String value) {
-            if (PARTSCACHE.containsKey(value))
-                return PARTSCACHE.get(value);
+            if (PARTSCACHE.containsKey(value)) {
+                Parts parts = PARTSCACHE.get(value);
+                if (null != parts)
+                    return parts;
+                PARTSCACHE.remove(value);
+            }
             Parts parts = new Parts(value);
             PARTSCACHE.put(value, parts);
             parts.prefix[parts.count] = value;

--- a/src/main/java/bsh/classpath/ClassManagerImpl.java
+++ b/src/main/java/bsh/classpath/ClassManagerImpl.java
@@ -35,11 +35,8 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import bsh.BshClassManager;
 import bsh.ClassPathException;
@@ -123,7 +120,7 @@ public class ClassManagerImpl extends BshClassManager
     private BshClassPath fullClassPath;
 
     // ClassPath Change listeners
-    private Set<WeakReference<Listener>> listeners = new LinkedHashSet<>();
+    private ConcurrentLinkedQueue<WeakReference<Listener>> listeners = new ConcurrentLinkedQueue<>();
     private ReferenceQueue<Listener> refQueue = new ReferenceQueue<>();
 
     /**
@@ -577,12 +574,6 @@ public class ClassManagerImpl extends BshClassManager
         return baseLoader;
     }
 
-    /**
-        Get the BeanShell classloader.
-    public ClassLoader getClassLoader() {
-    }
-    */
-
     /*
         Impl Notes:
         We add the bytecode source and the "reload" the class, which causes the
@@ -612,7 +603,7 @@ public class ClassManagerImpl extends BshClassManager
     */
     @Override
     protected void classLoaderChanged() {
-        List<WeakReference<Listener>> toRemove = new LinkedList<>(); // safely remove
+        ConcurrentLinkedQueue<WeakReference<Listener>> toRemove = new ConcurrentLinkedQueue<>(); // safely remove
         for (WeakReference<Listener> wr : listeners) {
             Listener l = wr.get();
             if (l == null) // garbage collected

--- a/src/main/java/bsh/util/ReferenceCache.java
+++ b/src/main/java/bsh/util/ReferenceCache.java
@@ -95,6 +95,7 @@ public abstract class ReferenceCache<K,V> {
      * If key is null or key already exist will do nothing.
      * Wraps the create method in a future task and starts a new process.
      * @param key associated with cache value */
+    @SuppressWarnings("FutureReturnValueIgnored") // see dereferenceValue
     public void init(K key) {
         if (null == key)
             return;

--- a/src/main/java/bsh/util/ReferenceCache.java
+++ b/src/main/java/bsh/util/ReferenceCache.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License. */
 package bsh.util;
-
 import static java.util.Objects.requireNonNull;
-
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 
@@ -32,6 +33,7 @@ import java.util.concurrent.FutureTask;
  * @param <K> the type of keys maintained by this cache
  * @param <V> the type of cached values */
 public abstract class ReferenceCache<K,V> {
+    private static final ExecutorService async = Executors.newCachedThreadPool();
     private final ConcurrentMap<CacheReference<K>,
                          Future<CacheReference<V>>> cache;
     private final ReferenceFactory<K,V> keyFactory;
@@ -100,11 +102,12 @@ public abstract class ReferenceCache<K,V> {
         if (cache.containsKey(refKey))
             return;
         FutureTask<CacheReference<V>> task = new FutureTask<>(()-> {
-            V created = requireNonNull(create(key));
+            V created = requireNonNull(create(key),
+                "Reference cache create value may not return null.");
             return valueFactory.createValue(created, queue);
         });
         cache.put(refKey, task);
-        task.run();
+        async.submit(task);
     }
 
     /** Remove cache entry associated with the given key.
@@ -152,7 +155,7 @@ public abstract class ReferenceCache<K,V> {
         try {
             return dereferenceValue(futureValue.get());
         } catch (final Throwable e) {
-            return null;
+            throw new CompletionException(e.getCause());
         }
     }
 
@@ -336,9 +339,9 @@ public abstract class ReferenceCache<K,V> {
         @Override
         public void run() {
             for (;;) try {
-                Reference<? extends T> ref = super.remove();
-                if (ref != null) ref.clear();
-            } catch (InterruptedException e) { /* ignore try again */ System.out.println(e+" ooops");}
+                Reference<? extends T> reference = super.remove();
+                reference.clear();
+            } catch (InterruptedException e) { /* ignore try again */ }
         }
     }
 }

--- a/src/test/java/bsh/BshMethodTest.java
+++ b/src/test/java/bsh/BshMethodTest.java
@@ -71,5 +71,4 @@ public class BshMethodTest {
        Assert.assertEquals("Equal classes should have equal hashcodes",
              method2.hashCode(), method1.hashCode());
     }
-
 }

--- a/src/test/java/bsh/BshScriptTestCase.java
+++ b/src/test/java/bsh/BshScriptTestCase.java
@@ -127,7 +127,7 @@ public class BshScriptTestCase {
      * @return true, if is under scrutiny */
     private static boolean isUnderScrutiny(final TestSuite suite) {
         // test file(s) under scrutiny
-        final String trouble_maker = _SCRIPT;
+        final String trouble_maker = null == _SCRIPT ? "" : _SCRIPT;
         if (trouble_maker.isEmpty())
             return false;
         for (String f:trouble_maker.split(","))

--- a/src/test/java/bsh/BshScriptTestCase.java
+++ b/src/test/java/bsh/BshScriptTestCase.java
@@ -23,9 +23,9 @@ import static bsh.KnownIssue.KNOWN_FAILING_TESTS;
 import static bsh.KnownIssue.SKIP_KNOWN_ISSUES;
 import static java.lang.System.err;
 import static java.lang.System.out;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeFalse;
 
 import java.io.File;

--- a/src/test/java/bsh/NodeStringTest.java
+++ b/src/test/java/bsh/NodeStringTest.java
@@ -1,0 +1,259 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+/****************************************************************************/
+
+package bsh;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class NodeStringTest {
+
+    /**
+     * Verify allocation expression to string.
+     */
+    @Test
+    public void test_allocation_expression_string() {
+        assertEquals("AllocationExpression", new BSHAllocationExpression(ParserTreeConstants.JJTALLOCATIONEXPRESSION).toString());
+    }
+
+    /**
+     * Verify ambiguous name to string.
+     */
+    @Test
+    public void test_ambiguous_name_string() {
+        assertEquals("AmbiguousName: null", new BSHAmbiguousName(ParserTreeConstants.JJTAMBIGUOUSNAME).toString());
+    }
+
+    /**
+     * Verify arguments to string.
+     */
+    @Test
+    public void test_arguments_string() {
+        assertEquals("Arguments", new BSHArguments(ParserTreeConstants.JJTARGUMENTS).toString());
+    }
+
+    /**
+     * Verify array dimensions to string.
+     */
+    @Test
+    public void test_array_dimensions_string() {
+        assertEquals("ArrayDimensions: 0, 0", new BSHArrayDimensions(ParserTreeConstants.JJTARRAYDIMENSIONS).toString());
+    }
+
+    /**
+     * Verify array initializer to string.
+     */
+    @Test
+    public void test_array_initializer_string() {
+        assertEquals("ArrayInitializer: false", new BSHArrayInitializer(ParserTreeConstants.JJTARRAYINITIALIZER).toString());
+    }
+
+    /**
+     * Verify assignment to string.
+     */
+    @Test
+    public void test_assignment_string() {
+        BSHAssignment node = new BSHAssignment(ParserTreeConstants.JJTASSIGNMENT);
+        assertEquals("Assignment", node.toString());
+        node.operator = ParserConstants.EOF;
+        assertEquals("Assignment: <EOF>", node.toString());
+    }
+
+    /**
+     * Verify binary expression to string.
+     */
+    @Test
+    public void test_binary_expression_string() {
+        assertEquals("BinaryExpression: <EOF>", new BSHBinaryExpression(ParserTreeConstants.JJTBINARYEXPRESSION).toString());
+    }
+
+    /**
+     * Verify block to string.
+     */
+    @Test
+    public void test_block_string() {
+        assertEquals("Block: static=false, synchronized=false", new BSHBlock(ParserTreeConstants.JJTBLOCK).toString());
+    }
+
+    /**
+     * Verify class declaration to string.
+     */
+    @Test
+    public void test_class_declaration_string() {
+        assertEquals("ClassDeclaration: null", new BSHClassDeclaration(ParserTreeConstants.JJTCLASSDECLARATION).toString());
+    }
+
+    /**
+     * Verify enhanced for statement to string.
+     */
+    @Test
+    public void test_enhanced_for_statement_string() {
+        assertEquals("EnhancedForStatement: null, final=false", new BSHEnhancedForStatement(ParserTreeConstants.JJTENHANCEDFORSTATEMENT).toString());
+    }
+
+    /**
+     * Verify enum constant to string.
+     */
+    @Test
+    public void test_enum_constant_string() {
+        assertEquals("EnumConstant: Modifiers: public static final enum class java.lang.Enum null", new BSHEnumConstant(ParserTreeConstants.JJTENUMCONSTANT).toString());
+    }
+
+    /**
+     * Verify formal comment to string.
+     */
+    @Test
+    public void test_formal_comment_string() {
+        assertEquals("FormalComment: null", new BSHFormalComment(ParserTreeConstants.JJTFORMALCOMMENT).toString());
+    }
+
+    /**
+     * Verify formal parameter to string.
+     */
+    @Test
+    public void test_formal_parameter_string() {
+        assertEquals("FormalParameter: null, final=false, varargs=false", new BSHFormalParameter(ParserTreeConstants.JJTFORMALPARAMETER).toString());
+    }
+
+    /**
+     * Verify for statement to string.
+     */
+    @Test
+    public void test_for_statement_string() {
+        assertEquals("ForStatement: false ; false ; false", new BSHForStatement(ParserTreeConstants.JJTFORSTATEMENT).toString());
+    }
+
+    /**
+     * Verify import declaration to string.
+     */
+    @Test
+    public void test_import_declaration_string() {
+        assertEquals("ImportDeclaration: static=false, *=false, super import=false", new BSHImportDeclaration(ParserTreeConstants.JJTIMPORTDECLARATION).toString());
+    }
+
+    /**
+     * Verify literal to string.
+     */
+    @Test
+    public void test_literal_string() {
+        assertEquals("Literal: null", new BSHLiteral(ParserTreeConstants.JJTLITERAL).toString());
+    }
+
+    /**
+     * Verify method declaration to string.
+     */
+    @Test
+    public void test_method_declaration_string() {
+        assertEquals("MethodDeclaration: null", new BSHMethodDeclaration(ParserTreeConstants.JJTMETHODDECLARATION).toString());
+    }
+
+    /**
+     * Verify multi catch to string.
+     */
+    @Test
+    public void test_multi_catch_string() {
+        assertEquals("MultiCatch: null, final=false", new BSHMultiCatch(ParserTreeConstants.JJTMULTICATCH).toString());
+    }
+
+    /**
+     * Verify primary suffix to string.
+     */
+    @Test
+    public void test_primary_suffix_string() {
+        BSHPrimarySuffix node = new BSHPrimarySuffix(ParserTreeConstants.JJTPRIMARYSUFFIX);
+        assertEquals("PrimarySuffix: class", node.toString());
+        node.operation = BSHPrimarySuffix.INDEX;
+        assertEquals("PrimarySuffix: [false:false false:false]", node.toString());
+        node.operation = BSHPrimarySuffix.NAME;
+        assertEquals("PrimarySuffix: null", node.toString());
+        node.operation = BSHPrimarySuffix.PROPERTY;
+        assertEquals("PrimarySuffix: {}", node.toString());
+        node.operation = BSHPrimarySuffix.NEW;
+        assertEquals("PrimarySuffix: new", node.toString());
+    }
+
+    /**
+     * Verify primitive type to string.
+     */
+    @Test
+    public void test_primitive_type_string() {
+        assertEquals("PrimitiveType: null", new BSHPrimitiveType(ParserTreeConstants.JJTPRIMITIVETYPE).toString());
+    }
+
+    /**
+     * Verify return statement to string.
+     */
+    @Test
+    public void test_return_statement_string() {
+        assertEquals("ReturnStatement: <EOF>", new BSHReturnStatement(ParserTreeConstants.JJTRETURNSTATEMENT).toString());
+    }
+
+    /**
+     * Verify return type to string.
+     */
+    @Test
+    public void test_return_type_string() {
+        assertEquals("ReturnType: void=false", new BSHReturnType(ParserTreeConstants.JJTRETURNTYPE).toString());
+    }
+
+    /**
+     * Verify switch label to string.
+     */
+    @Test
+    public void test_switch_label_string() {
+        BSHSwitchLabel node = new BSHSwitchLabel(ParserTreeConstants.JJTSWITCHLABEL);
+        assertEquals("SwitchLabel: case", node.toString());
+        node.isDefault = true;
+        assertEquals("SwitchLabel: default", node.toString());
+    }
+
+    /**
+     * Verify typed variable declaration to string.
+     */
+    @Test
+    public void test_typed_variable_declaration_string() {
+        assertEquals("TypedVariableDeclaration: Modifiers: ", new BSHTypedVariableDeclaration(ParserTreeConstants.JJTTYPEDVARIABLEDECLARATION).toString());
+    }
+
+    /**
+     * Verify unary expression to string.
+     */
+    @Test
+    public void test_unary_expression_string() {
+        assertEquals("UnaryExpression: <EOF>", new BSHUnaryExpression(ParserTreeConstants.JJTUNARYEXPRESSION).toString());
+    }
+
+    /**
+     * Verify variable declarator to string.
+     */
+    @Test
+    public void test_variable_declarator_string() {
+        assertEquals("VariableDeclarator: null", new BSHVariableDeclarator(ParserTreeConstants.JJTVARIABLEDECLARATOR).toString());
+    }
+
+    /**
+     * Verify while statement to string.
+     */
+    @Test
+    public void test_while_statement_string() {
+        assertEquals("WhileStatement: do=false", new BSHWhileStatement(ParserTreeConstants.JJTWHILESTATEMENT).toString());
+    }
+}

--- a/src/test/java/bsh/ReferenceCacheTest.java
+++ b/src/test/java/bsh/ReferenceCacheTest.java
@@ -1,39 +1,55 @@
 package bsh;
 
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import bsh.util.ReferenceCache;
 import static bsh.util.ReferenceCache.Type.Hard;
 import static bsh.util.ReferenceCache.Type.Soft;
 import static bsh.util.ReferenceCache.Type.Weak;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Rule;
-
+import java.util.concurrent.CompletionException;
 
 @RunWith(FilteredTestRunner.class)
 public class ReferenceCacheTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void hard_reference_key() throws Exception {
+    public void hard_reference_key() {
+        ReferenceCache<String,Integer> cache = new ReferenceCache<String,Integer>(Hard, Hard) {
+            protected Integer create(String key) { return 0; }};
+        cache.init("foo");
+
+        assertThat(cache.size(), equalTo(1));
+        assertThat(cache.get("foo"), equalTo(0));
+        System.gc();
+    }
+
+    @Test
+    public void hard_reference_null_value() {
         ReferenceCache<String,Void> cache = new ReferenceCache<String,Void>(Hard, Hard) {
             protected Void create(String key) { return null; }};
         cache.init("foo");
 
         assertThat(cache.size(), equalTo(1));
-        assertThat(cache.get("foo"), nullValue());
+        Exception e = assertThrows(CompletionException.class, () -> cache.get("foo"));
+        assertThat(e.getCause(), instanceOf(NullPointerException.class));
+        assertThat(e.getCause().getMessage(),
+            containsString("Reference cache create value may not return null."));
         System.gc();
     }
 
     @Test
-    public void hard_reference_value() throws Exception {
+    public void hard_reference_value() {
         ReferenceCache<String,String> cache = new ReferenceCache<String,String>(Hard, Hard) {
             protected String create(String key) { return "bar"; }};
         cache.init("foo");
@@ -44,18 +60,32 @@ public class ReferenceCacheTest {
     }
 
     @Test
-    public void soft_reference_key() throws Exception {
+    public void soft_reference_key() {
+        ReferenceCache<String,Integer> cache = new ReferenceCache<String,Integer>(Soft, Soft) {
+            protected Integer create(String key) { return 0; }};
+        cache.init("foo");
+
+        assertThat(cache.size(), equalTo(1));
+        assertThat(cache.get("foo"), equalTo(0));
+        System.gc();
+    }
+
+    @Test
+    public void soft_reference_null_value() {
         ReferenceCache<String,Void> cache = new ReferenceCache<String,Void>(Soft, Soft) {
             protected Void create(String key) { return null; }};
         cache.init("foo");
 
         assertThat(cache.size(), equalTo(1));
-        assertThat(cache.get("foo"), nullValue());
+        Exception e = assertThrows(CompletionException.class, () -> cache.get("foo"));
+        assertThat(e.getCause(), instanceOf(NullPointerException.class));
+        assertThat(e.getCause().getMessage(),
+            containsString("Reference cache create value may not return null."));
         System.gc();
     }
 
     @Test
-    public void soft_reference_value() throws Exception {
+    public void soft_reference_value() {
         ReferenceCache<String,String> cache = new ReferenceCache<String,String>(Soft, Soft) {
             protected String create(String key) { return "bar"; }};
         cache.init("foo");
@@ -66,18 +96,32 @@ public class ReferenceCacheTest {
     }
 
     @Test
-    public void weak_reference_key() throws Exception {
+    public void weak_reference_key() {
+        ReferenceCache<String,Integer> cache = new ReferenceCache<String,Integer>(Weak, Weak) {
+            protected Integer create(String key) { return 0; }};
+        cache.init("foo");
+
+        assertThat(cache.size(), equalTo(1));
+        assertThat(cache.get("foo"), equalTo(0));
+        System.gc();
+    }
+
+    @Test
+    public void weak_reference_null_value() {
         ReferenceCache<String,Void> cache = new ReferenceCache<String,Void>(Weak, Weak){
             protected Void create(String key) { return null; }};
         cache.init("foo");
 
         assertThat(cache.size(), equalTo(1));
-        assertThat(cache.get("foo"), nullValue());
+        Exception e = assertThrows(CompletionException.class, () -> cache.get("foo"));
+        assertThat(e.getCause(), instanceOf(NullPointerException.class));
+        assertThat(e.getCause().getMessage(),
+            containsString("Reference cache create value may not return null."));
         System.gc();
     }
 
     @Test
-    public void weak_reference_value() throws Exception {
+    public void weak_reference_value() {
         ReferenceCache<String,String> cache = new ReferenceCache<String,String>(Weak, Weak){
             protected String create(String key) { return "bar"; }};
         cache.init("foo");
@@ -88,18 +132,19 @@ public class ReferenceCacheTest {
     }
 
     @Test
-    public void null_cache_key() throws Exception {
+    public void null_cache_key() {
         ReferenceCache<String,String> cache = new ReferenceCache<String,String>(Weak, Weak, 2){
             protected String create(String key) { return "bar"; }};
         cache.init(null);
 
         assertThat(cache.get(null), nullValue());
+        assertThat(cache.size(), equalTo(0));
         System.gc();
     }
 
 
     @Test
-    public void remove_cache_entry() throws Exception {
+    public void remove_cache_entry() {
         ReferenceCache<String,String> cache = new ReferenceCache<String,String>(Weak, Weak){
             protected String create(String key) { return "bar"; }};
         cache.init("foo");
@@ -108,7 +153,53 @@ public class ReferenceCacheTest {
         assertThat(cache.get("foo"), equalTo("bar"));
         assertTrue(cache.remove("foo"));
         assertThat(cache.size(), equalTo(0));
+        assertFalse(cache.remove(null));
         System.gc();
+    }
+
+    @Test
+    public void hard_garbage_collect() {
+        final int[] cnt = new int[1];
+        ReferenceCache<Integer,byte[]> cache = new ReferenceCache<Integer,byte[]>(Hard, Hard){
+            protected byte[] create(Integer key) { return new byte[1024*100]; }};
+        while (cnt[0]++ < 10) {
+            cache.init(cnt[0]);
+            System.gc();
+            assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+        }
+        System.gc();
+        assertNotEquals(cache.size(), cnt[0]);
+        assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+    }
+
+    @Test
+    public void soft_garbage_collect() {
+        final int[] cnt = new int[1];
+        ReferenceCache<Integer,byte[]> cache = new ReferenceCache<Integer,byte[]>(Soft, Soft){
+            protected byte[] create(Integer key) { return new byte[1024*100]; }};
+        while (cnt[0]++ < 10) {
+            cache.init(cnt[0]);
+            System.gc();
+            assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+        }
+        System.gc();
+        assertNotEquals(cache.size(), cnt[0]);
+        assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+    }
+
+    @Test
+    public void weak_garbage_collect() {
+        final int[] cnt = new int[1];
+        ReferenceCache<Integer,byte[]> cache = new ReferenceCache<Integer,byte[]>(Weak, Weak){
+            protected byte[] create(Integer key) { return new byte[1024*100]; }};
+        while (cnt[0]++ < 10) {
+            cache.init(cnt[0]);
+            System.gc();
+            assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+        }
+        System.gc();
+        assertNotEquals(cache.size(), cnt[0]);
+        assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
     }
 }
 

--- a/src/test/resources/test-scripts/bean_properties.bsh
+++ b/src/test/resources/test-scripts/bean_properties.bsh
@@ -12,6 +12,10 @@ public class TestClass {
     private boolean _instBoolProp;
     // not boolean
     private long _instNotBoolean;
+    // has no getter
+    private int _noGet;
+    // has no setter
+    private int _noSet;
     // instance bean accessor methods
     public int getInstProp() { return _instProp; }
     public void setInstProp(int _instProp) { this._instProp = _instProp; }
@@ -38,6 +42,11 @@ public class TestClass {
     public static long isStatNotBoolean() { return _statNotBoolean; }
     // force change statVar
     public static void changeStatVar() { _statVar++; }
+
+    // test null find proprety
+    public static void setNoGet(int var) { _noGet = var; }
+    public static int getNoSet() { return _noSet; }
+
 }
 
 obj = new TestClass();
@@ -63,6 +72,9 @@ obj.instBoolProp = false;
 assertThat(obj.instBoolProp, equalTo(false));
 // not a bean property
 assertTrue(obj.instNotBoolean == void);
+//test null find proprety
+assert(isEvalError("No such property: noSet", 'obj.noSet = 1;'));
+assert(isEvalError("illegal void assignment", 'a = obj.noGet;'));
 
 // class static members
 // private static field
@@ -151,6 +163,5 @@ statBoolProp = false;
 assertThat(statBoolProp, equalTo(false));
 //not a bean property
 assertTrue(statNotBoolean == void);
-
 
 complete();


### PR DESCRIPTION
Was getting annoyed with the [intermittent failure](https://github.com/beanshell/beanshell/actions/runs/3370982286/jobs/6052971608) of the `InterpreterConcurrencyTest` so fixed it. Failing tests, intermittent or otherwise, should be considered show stoppers and takes precedence over anything else, I am sure you will agree. The problem was that the value references from the [WeakHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/WeakHashMap.html) was finalized but the key entries never gets cleaned up, which was [one motivation](https://github.com/beanshell/beanshell/issues/502) for developing the reference cache, see below. Not sure if this resolves #655, lacking a root cause analysis or unit test, since this issue specifically pertains to the dot notation in references. We are also using `WeakHashMap` in `Reflection` and `Capabilities` so the issue may be related.

Also took this time to address [the issues raised](https://github.com/beanshell/beanshell/commit/32e8be51001be388743dac45376a699c9549c41a#r59935262) on the asynchronicity of `ReferencheCache`. @opeongo please review this PR and confirm that you agree with the changes.

I went with option 3 [from the discussion](https://github.com/beanshell/beanshell/commit/32e8be51001be388743dac45376a699c9549c41a#r91477762) since we may or may not actually use the reference it pays not to be blocking for initialization (use async instead), yet still populate the reference cache as expected (instead of opting for lazy loading). To mitigate the concern of spawning hundreds of threads I have opted for a [cached thread pool](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newCachedThreadPool--) which will reuse previous threads if available but also clear them if idle and not consume unnecessary resources, which seems the best of both worlds. 

It is worth mentioning that the concern raised in option 2 about not having the values loaded as weak or soft references is invalid. The reference cache uses a self monitoring [reference queue](https://docs.oracle.com/javase/8/docs/api/java/lang/ref/ReferenceQueue.html) process registered on the cache keys, which will remove cache entries when the keys are invalidated, something not implemented for the standard [WeakHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/WeakHashMap.html). Which makes the lazy load probably the best option but it changes the original intentions of the reference cache design and I opted for option 3 as it has the least impact (talk about lazy). We should probably replace all the `WeakHashMaps` with `ReferenceCache` but that is a bigger challenge in itself, because it is not a drop in replacement and takes a completely different approach to populating the collection which enables the automatic re-initializing of expired values removed from the cache when requested.

Using the maven build process and testing completion time as a benchmark, I know this is not a scientific bench but still a ballpark, the cached thread pool is a slight improvement over the current non-asynchronous implementation but significantly faster than simply spawning new threads for each request which quickly takes a toll. I was unable to see a speed difference compared with a fixed pool, but if you have a long running test (more than a minute), the memory footprint is much smaller with the timed out threads.

There was another annoying bug I picked up with exceptions being obfuscated by the reference cache and not rolling up to the client. This also allowed for null values which the cache specifically disallows because it needs null state to test whether a reference expired or not. This has been rectified and an appropriate null pointer exception message was added to distinguish the problem from other NPEs.

Added several more tests for the reference queue, also proving cache expiry and auto reinitialize of expired entries, reaching 99% test coverage, which seems like the best we are going to get unless someone else can do better.

Changes in this commit includes:
* Fix issue with `InterpreterConcurrency` Test failing periodically
* Expose lazy loaded exceptions obscured by `dereferenceValue's` catch block
* Fixed future task asynchronous process via static final cached thread pool
* Removed debug output from `ReferenceQueueMonitor's` empty catch block
* Add message to `requireNonNull` as specified for values
* Fix key tests assigning null values and added tests for NPE checks
* Fixed deprecated `assertThat` and `ExpectedException` on `ReferenceCacheTest`
* Removed redundant throws Exception from test cases
* Added tests to prove removal of finalized references
* Added tests to prove auto reinitialize of expired references
* Reached 99% code coverage on `ReferenceCache` and appears to be the limit