### PR TITLE
Running unit tests with restricted heap size

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Sun Dec 11 05:00:12 SAST 2022
-build=1169
+#Tue Dec 13 19:27:41 SAST 2022
+build=1518
 release=${project.version}

--- a/src/main/java/bsh/BSHType.java
+++ b/src/main/java/bsh/BSHType.java
@@ -31,14 +31,15 @@ package bsh;
 import java.lang.reflect.Array;
 
 class BSHType extends SimpleNode
-    implements BshClassManager.Listener
+    //implements BshClassManager.Listener
 {
+    private static final long serialVersionUID = 1L;
     /**
         baseType is used during evaluation of full type and retained for the
         case where we are an array type.
         In the case where we are not an array this will be the same as type.
     */
-    private Class baseType;
+    private Class<?> baseType;
     /**
         If we are an array type this will be non zero and indicate the
         dimensionality of the array.  e.g. 2 for String[][];
@@ -48,7 +49,7 @@ class BSHType extends SimpleNode
     /**
         Internal cache of the type.  Cleared on classloader change.
     */
-    private Class type;
+    private Class<?> type;
 
     String descriptor;
 
@@ -97,7 +98,7 @@ class BSHType extends SimpleNode
             // manager.
             String definingClass = bcm.getClassBeingDefined( clasName );
 
-            Class clas = null;
+            Class<?> clas = null;
             if ( definingClass == null )
             {
                 try {
@@ -107,14 +108,12 @@ class BSHType extends SimpleNode
                     // Lets assume we have a generics raw type
                     if (clasName.length() == 1)
                         clasName = "java.lang.Object";
-                    //System.out.println("BSHType: "+node+" class not found");
                 }
             } else
                 clasName = definingClass;
 
             if ( clas != null )
             {
-                //System.out.println("found clas: "+clas);
                 descriptor = getTypeDescriptor( clas );
             }else
             {
@@ -130,11 +129,10 @@ class BSHType extends SimpleNode
             descriptor = "["+descriptor;
 
         this.descriptor = descriptor;
-    //System.out.println("BSHType: returning descriptor: "+descriptor);
         return descriptor;
     }
 
-    public Class getType( CallStack callstack, Interpreter interpreter )
+    public Class<?> getType( CallStack callstack, Interpreter interpreter )
         throws EvalError
     {
         // return cached type if available
@@ -174,8 +172,16 @@ class BSHType extends SimpleNode
             type = baseType;
 
         // hack... sticking to first interpreter that resolves this
-        // see comments on type instance variable
-        interpreter.getClassManager().addListener(this);
+        // see comments on type instance variable (in header on SimpleNode)
+        // -------
+        // This has been here since the first commit, not sure if it is only
+        // theoretical or an actual concern. Yes some blocks are reiterated
+        // processing nodes again but what would make a previously scripted,
+        // interpreted, and executed type change on the fly?
+        // Leaving this commented here for now as a reference if things go
+        // wrong but should it be removed one day it must go with the interface
+        // BshClassManager.Listener and contract method classLoaderChanged()
+//         interpreter.getClassManager().addListener(this);
 
         return type;
     }
@@ -185,7 +191,7 @@ class BSHType extends SimpleNode
         case where we are an array type.
         In the case where we are not an array this will be the same as type.
     */
-    public Class getBaseType() {
+    public Class<?> getBaseType() {
         return baseType;
     }
     /**
@@ -196,12 +202,12 @@ class BSHType extends SimpleNode
         return arrayDims;
     }
 
-    public void classLoaderChanged() {
-        type = null;
-        baseType = null;
-    }
+//    public void classLoaderChanged() {
+//        type = null;
+//        baseType = null;
+//    }
 
-    public static String getTypeDescriptor( Class clas )
+    public static String getTypeDescriptor( Class<?> clas )
     {
         if ( clas == Boolean.TYPE ) return "Z";
         if ( clas == Character.TYPE ) return "C";

--- a/src/main/java/bsh/classpath/ClassManagerImpl.java
+++ b/src/main/java/bsh/classpath/ClassManagerImpl.java
@@ -32,10 +32,10 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -606,7 +606,7 @@ public class ClassManagerImpl extends BshClassManager
     */
     @Override
     protected void classLoaderChanged() {
-        List<WeakReference<Listener>> toRemove = new LinkedList<>(); // safely remove
+        List<WeakReference<Listener>> toRemove = new ArrayList<>(); // safely remove
         for (WeakReference<Listener> wr : listeners) {
             Listener l = wr.get();
             if (l == null) // garbage collected

--- a/src/main/resources/bsh/commands/addClassPath.bsh
+++ b/src/main/resources/bsh/commands/addClassPath.bsh
@@ -23,7 +23,7 @@ addClassPath( path ) {
     if ( path instanceof URL )
         url = path;
     else
-        url = pathToFile( path ).toURL();
+        url = pathToFile( path ).toURI().toURL();
 
     this.caller.namespace.getClassManager().addClassPath( url );
 }

--- a/src/main/resources/bsh/commands/exec.bsh
+++ b/src/main/resources/bsh/commands/exec.bsh
@@ -11,4 +11,5 @@ exec( String arg )
     this.din = new DataInputStream( proc.getInputStream() );
     while( (line=din.readLine()) != null )
         print(line);
+    return this.proc.exitValue();
 }

--- a/src/test/java/bsh/BshSerializationTest.java
+++ b/src/test/java/bsh/BshSerializationTest.java
@@ -44,6 +44,8 @@ public class BshSerializationTest {
         assertNull(origInterpreter.eval("myNull"));
         final Interpreter deserInterpreter = TestUtil.serDeser(origInterpreter);
         assertNull(deserInterpreter.eval("myNull"));
+        origInterpreter.getNameSpace().clear();
+        deserInterpreter.getNameSpace().clear();
     }
 
     /**
@@ -57,6 +59,8 @@ public class BshSerializationTest {
         assertTrue((Boolean) originalInterpreter.eval("myNull == null"));
         final Interpreter deserInterpreter = TestUtil.serDeser(originalInterpreter);
         assertTrue((Boolean) deserInterpreter.eval("myNull == null"));
+        originalInterpreter.getNameSpace().clear();
+        deserInterpreter.getNameSpace().clear();
     }
 
     /**
@@ -69,5 +73,7 @@ public class BshSerializationTest {
         assertTrue((Boolean) originalInterpreter.eval("myVoid == void"));
         final Interpreter deserInterpreter = TestUtil.serDeser(originalInterpreter);
         assertTrue((Boolean) deserInterpreter.eval("myVoid == void"));
+        originalInterpreter.getNameSpace().clear();
+        deserInterpreter.getNameSpace().clear();
     }
 }

--- a/src/test/java/bsh/CallStackTest.java
+++ b/src/test/java/bsh/CallStackTest.java
@@ -36,5 +36,7 @@ public class CallStackTest {
         nameSpace.setLocalVariable("test", "test", false);
         final CallStack stack = TestUtil.serDeser(new CallStack(nameSpace));
         Assert.assertEquals("test", stack.top().get("test", null));
+        stack.clear();
+        nameSpace.clear();
     }
 }

--- a/src/test/java/bsh/ClassGeneratorTest.java
+++ b/src/test/java/bsh/ClassGeneratorTest.java
@@ -24,12 +24,12 @@ import static bsh.TestUtil.eval;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Callable;
 import java.util.function.IntSupplier;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -102,6 +102,7 @@ public class ClassGeneratorTest {
         final Interpreter interpreter = new Interpreter();
         interpreter.setStrictJava(true);
         interpreter.eval("class Test { abstract void x(); }");
+        interpreter.getNameSpace().clear();
     }
 
     @Test

--- a/src/test/java/bsh/EnumTest.java
+++ b/src/test/java/bsh/EnumTest.java
@@ -6,12 +6,12 @@ import org.junit.runner.RunWith;
 
 import static bsh.TestUtil.eval;
 import static bsh.TestUtil.script;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.arrayContaining;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Rule;
@@ -101,6 +101,7 @@ public class EnumTest {
         assertThat("array containing VAL1, VAL2, VAL3, VAL4", obj, arrayContaining(
                 bsh.eval("E4.VAL1"), bsh.eval("E4.VAL2"),
                 bsh.eval("E4.VAL3"), bsh.eval("E4.VAL4")));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -117,6 +118,7 @@ public class EnumTest {
         assertThat("array containing VAL1, VAL2, VAL3, VAL4", obj, arrayContaining(
                 bsh.eval("E4.VAL1"), bsh.eval("E4.VAL2"),
                 bsh.eval("E4.VAL3"), bsh.eval("E4.VAL4")));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -133,6 +135,7 @@ public class EnumTest {
         assertThat("array containing VAL1, VAL2, VAL3, VAL4", obj, arrayContaining(
                 bsh.eval("E4.VAL1"), bsh.eval("E4.VAL2"),
                 bsh.eval("E4.VAL3"), bsh.eval("E4.VAL4")));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -149,6 +152,7 @@ public class EnumTest {
         assertThat("array containing VAL1, VAL2, VAL3, VAL4", obj, arrayContaining(
                 bsh.eval("E4.VAL1"), bsh.eval("E4.VAL2"),
                 bsh.eval("E4.VAL3"), bsh.eval("E4.VAL4")));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -259,6 +263,7 @@ public class EnumTest {
         assertThat("val1 switched", bsh.eval("switchit(Name.VAL1);"), equalTo("val1"));
         assertThat("default switched null", bsh.eval("switchit(null);"), equalTo("default"));
         assertThat("default switched string", bsh.eval("switchit('VAL1');"), equalTo("default"));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -341,6 +346,7 @@ public class EnumTest {
         assertThat("enum args VAL2 constructor set value i", bsh.eval("Name.VAL2.i"), equalTo(2));
         assertThat("enum args VAL2 constructor set value d", bsh.eval("Name.VAL2.d"), equalTo(2.0));
         assertThat("enum args VAL2 constructor set value s", bsh.eval("Name.VAL2.s"), equalTo("v2"));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -400,6 +406,7 @@ public class EnumTest {
         ));
         assertThat("enum block variable VAL2", bsh.eval("Name.VAL2.val"), equalTo("val2"));
         assertThat("enum block variable VAL1", bsh.eval("Name.VAL1.val"), equalTo("val1"));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -417,6 +424,7 @@ public class EnumTest {
         ));
         assertThat("enum block variable VAL2", bsh.eval("Name.VAL2.get()"), equalTo("val2"));
         assertThat("enum block variable VAL1", bsh.eval("Name.VAL1.get()"), equalTo("val1"));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -435,6 +443,7 @@ public class EnumTest {
         ));
         assertThat("enum block variable VAL2", bsh.eval("Name.VAL2.get()"), equalTo("val2"));
         assertThat("enum block variable VAL1", bsh.eval("Name.VAL1.get()"), equalTo("val1"));
+        bsh.getNameSpace().clear();
     }
 
     @Test
@@ -456,6 +465,7 @@ public class EnumTest {
         ));
         assertThat("enum block variable VAL2", bsh.eval("Name.VAL2.get()"), equalTo("2val2"));
         assertThat("enum block variable VAL1", bsh.eval("Name.VAL1.get()"), equalTo("1val1"));
+        bsh.getNameSpace().clear();
     }
 
 }

--- a/src/test/java/bsh/FinalModifierTest.java
+++ b/src/test/java/bsh/FinalModifierTest.java
@@ -5,10 +5,10 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static bsh.TestUtil.eval;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Rule;
 

--- a/src/test/java/bsh/GoogleReportsTest.java
+++ b/src/test/java/bsh/GoogleReportsTest.java
@@ -95,6 +95,7 @@ public class GoogleReportsTest {
         assertEquals("public-Number", interpreter.eval("return x.issue6(new Integer(9));"));
         setAccessibility(true);
         assertTrue("accessibility remains true", haveAccessibility());
+        interpreter.getNameSpace().clear();
     }
 
     /**
@@ -110,6 +111,7 @@ public class GoogleReportsTest {
         setAccessibility(true);
         assertEquals("private-Integer", interpreter.eval("return x.issue6(new Integer(9));"));
         assertTrue("accessibility remains true", haveAccessibility());
+        interpreter.getNameSpace().clear();
     }
 
     /*

--- a/src/test/java/bsh/InterfaceMethodsTest.java
+++ b/src/test/java/bsh/InterfaceMethodsTest.java
@@ -9,9 +9,9 @@ import mypackage.IFoo;
 import static bsh.TestUtil.eval;
 import static bsh.TestUtil.script;
 import static bsh.matchers.StringUtilValue.valueString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -86,6 +86,7 @@ public class InterfaceMethodsTest {
             "class AAC implements AA {}",
             "AAC.ab();"
         ));
+        interpreter.getNameSpace().clear();
     }
 
     @Test
@@ -114,6 +115,7 @@ public class InterfaceMethodsTest {
             "}",
             "class ZZC implements ZZ { }"
         ));
+        interpreter.getNameSpace().clear();
     }
 
     @Test
@@ -129,6 +131,7 @@ public class InterfaceMethodsTest {
             "}",
             "class ZZC implements ZZ { protected int ab() { 1; } }"
         ));
+        interpreter.getNameSpace().clear();
     }
 
     @Test
@@ -204,6 +207,7 @@ public class InterfaceMethodsTest {
         assertEquals("int field value is 5 (called 5 times)", 5, (int)foo.run().get(3));
         assertFalse("Boolean wrapper type field is NOT Primitive", (Boolean)foo.run().get(4));
         assertTrue("Boolean wrapper type field value is true", (Boolean)foo.run().get(5));
+        bsh.getNameSpace().clear();
     }
 
 }

--- a/src/test/java/bsh/InterpreterConcurrencyTest.java
+++ b/src/test/java/bsh/InterpreterConcurrencyTest.java
@@ -25,6 +25,7 @@ import static bsh.TestUtil.script;
 import static bsh.TestUtil.measureConcurrentTime;
 import org.junit.Test;
 
+import java.lang.ref.WeakReference;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -55,9 +56,11 @@ public class InterpreterConcurrencyTest {
 
     @Test
     public void single_threaded() throws Exception {
-        final This callable = createCallable();
+        final Interpreter interpreter = new Interpreter();
+        final This callable = (This) interpreter.eval(script);
         assertEquals("foo", callable.invokeMethod("call", new Object[] { "foo" }));
         assertEquals(42, callable.invokeMethod("call", new Object[] { 42 }));
+        interpreter.getNameSpace().clear();
     }
 
 
@@ -83,6 +86,7 @@ public class InterpreterConcurrencyTest {
             }
         };
         measureConcurrentTime(runnable, 30, 30, 100);
+        interpreter.getNameSpace().clear();
     }
 
     @Test
@@ -90,14 +94,14 @@ public class InterpreterConcurrencyTest {
         final Interpreter interpreter = new Interpreter();
         final This callable = (This) interpreter.eval(script);
         final AtomicInteger counter = new AtomicInteger();
-        final ConcurrentLinkedQueue<byte[]> heap = new ConcurrentLinkedQueue<>();
+        final ConcurrentLinkedQueue<WeakReference<byte[]>> heap = new ConcurrentLinkedQueue<>();
         final Runnable runnable = new Runnable() {
             public void run() {
                 try {
                     final int i = counter.incrementAndGet();
                     final Object o = callable.invokeMethod("call", new Object[]{i});
                     assertEquals(i, o);
-                    heap.add(new byte[1024*1000]);
+                    heap.add(new WeakReference<byte[]>(new byte[1024*1000]));
                     try { interpreter.eval("System.gc();"); } catch (Exception e) {/*ignore*/};
                 } catch (final EvalError evalError) {
                     throw new RuntimeException(evalError);
@@ -105,11 +109,13 @@ public class InterpreterConcurrencyTest {
             }
         };
         measureConcurrentTime(runnable, 3, 3, 100);
+        interpreter.getNameSpace().clear();
     }
 
     @Test
     public void multi_threaded_class_generation() throws Exception {
-        final This callable = createCallable();
+        final Interpreter interpreter = new Interpreter();
+        final This callable = (This) interpreter.eval(script);
         final AtomicInteger counter = new AtomicInteger();
         final Runnable runnable = new Runnable() {
             public void run() {
@@ -123,12 +129,7 @@ public class InterpreterConcurrencyTest {
             }
         };
         measureConcurrentTime(runnable, 30, 30, 100);
-    }
-
-
-    private This createCallable() throws Exception {
-        final Interpreter interpreter = new Interpreter();
-        return (This) interpreter.eval(script);
+        interpreter.getNameSpace().clear();
     }
 
 }

--- a/src/test/java/bsh/InterpreterTest.java
+++ b/src/test/java/bsh/InterpreterTest.java
@@ -83,7 +83,7 @@ public class InterpreterTest {
      */
     @Test(timeout = 10000)
     public void check_for_memory_leak() throws Exception {
-        final WeakReference<Object> reference = new WeakReference<Object>(new Interpreter().eval("x = new byte[1024 * 2024]; return x;"));
+        final WeakReference<Object> reference = new WeakReference<Object>(new Interpreter().eval("x = new byte[1024 * 1000]; return x;"));
         while (reference.get() != null) {
             System.gc();
             Thread.sleep(1);
@@ -127,6 +127,7 @@ public class InterpreterTest {
         assertSame(one, six.getParent());
         assertEquals("known source", six.getSourceFileInfo());
         assertEquals("twoSpace", six.globalNameSpace.getName());
+        one.getNameSpace().clear();
     }
 
     @Test

--- a/src/test/java/bsh/InvocableTest.java
+++ b/src/test/java/bsh/InvocableTest.java
@@ -3,9 +3,9 @@ package bsh;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.invoke.MethodType;

--- a/src/test/java/bsh/ReflectTest.java
+++ b/src/test/java/bsh/ReflectTest.java
@@ -6,6 +6,7 @@ import static bsh.TestUtil.eval;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.sameInstance;
@@ -13,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;

--- a/src/test/java/bsh/SourceForgeIssuesTest.java
+++ b/src/test/java/bsh/SourceForgeIssuesTest.java
@@ -28,11 +28,11 @@ import org.junit.runner.RunWith;
 import static bsh.Capabilities.haveAccessibility;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static bsh.TestUtil.eval;
 
@@ -117,6 +117,7 @@ public class SourceForgeIssuesTest {
             Interpreter.DEBUG.set(false);
             assertEquals("null", ret.trim());
             assertTrue(baOut.toString().contains("args[0] = null type"));
+            bsh.getNameSpace().clear();
         }
     }
 
@@ -245,16 +246,17 @@ public class SourceForgeIssuesTest {
             assertTrue(e.getTarget().getClass() == RuntimeException.class);
         }
         assertEquals("foobar", eval("String a=null;", "try {", " a = \"foobar\";", "} catch (Exception e) {", "  throw e;", "}", "return a;"));
-        String script = "boolean fieldBool = false;\n" +
+        String script = "import org.junit.Assert;\n" +
+                "boolean fieldBool = false;\n" +
                 "int fieldInt = 0;\n" +
                 "Boolean fieldBool2 = false;\n" +
                 "void run() {\n" +
                 "fieldBool = ! fieldBool;\n" +
                 "fieldBool2 = ! fieldBool2;\n" +
                 "fieldInt++;\n" +
-                "//System.out.println(\"fieldBool: \"+fieldBool);\n" +
-                "//System.out.println(\"fieldBool2: \"+fieldBool2);\n" +
-                "//System.out.println(\"fieldInt: \"+fieldInt);\n" +
+                "Assert.assertTrue(fieldBool);\n" +
+                "Assert.assertTrue(fieldBool2);\n" +
+                "Assert.assertTrue(fieldInt == 1);\n" +
                 "}\n";
         Interpreter bsh = new Interpreter();
         bsh.eval(script);

--- a/src/test/java/bsh/StatementsTest.java
+++ b/src/test/java/bsh/StatementsTest.java
@@ -4,9 +4,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static bsh.TestUtil.eval;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 @RunWith(FilteredTestRunner.class)
 public class StatementsTest {

--- a/src/test/java/bsh/TryStatementTest.java
+++ b/src/test/java/bsh/TryStatementTest.java
@@ -16,13 +16,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static bsh.TestUtil.eval;
 import static bsh.TestUtil.toMap;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/resources/test-scripts/array1.bsh
+++ b/src/test/resources/test-scripts/array1.bsh
@@ -39,7 +39,7 @@ a[0] = 1;
 assertArrayEquals( a, new Long[] {1,0,0,0,0} );
 
 a = new BigInteger[5];
-a[0] = BigInteger.valueOf(1);
+a[0] = BigInteger.valueOf(1L);
 assertArrayEquals( a, new BigInteger[] {1,0,0,0,0});
 
 

--- a/src/test/resources/test-scripts/class14.bsh
+++ b/src/test/resources/test-scripts/class14.bsh
@@ -1,5 +1,7 @@
 source("TestHarness.bsh");
 
+list = new List {};
+
 class TestInner22
 {
     static int s = 5;
@@ -18,6 +20,7 @@ class TestInner22
                 assert( this instanceof Runnable );
                 assert( TestInner22.this == t22This );
                 assert(i==4);
+                list.add(null);
             }
         };
         new Thread(r).start();
@@ -27,10 +30,12 @@ class TestInner22
                 assert( this instanceof Thread );
                 assert( TestInner22.this == t22This );
                 assert(i==4);
+                list.add(null);
             }
         }.start();
 
         new MyThread().start();
+        new MyStaticThread().start();
     }
 
     class MyThread extends Thread {
@@ -38,6 +43,7 @@ class TestInner22
             assert( this instanceof Thread );
             assert( TestInner22.this == t22This );
             assert( i == 4 );
+            list.add(null);
         }
     }
 
@@ -47,10 +53,12 @@ class TestInner22
             assert( this instanceof Thread );
             assert( isEvalError("TestInner22.this") );
             assert( isEvalError("i") );
+            list.add(null);
         }
     }
 }
 
 new TestInner22().go();
-
+while (list.size() < 5)
+    Thread.sleep(20);
 complete();


### PR DESCRIPTION
I was trying to reduce the available memory for running unit tests, in the hopes that it will reveal our problems.

Managed to reduce the memory required to run the tests, where all tests will now succeed within 15MB of heap and the bsh scripted tests alone can complete in only 11MB of heap space.

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-surefire-plugin</artifactId>
    <version>3.0.0-M5</version>
    <configuration>
        <trimStackTrace>false</trimStackTrace>
        <argLine>-Xmx11M -XX:+UseSerialGC ${surefireArgLine}</argLine>
        <systemPropertyVariables>
            <bsh.debugClasses />
            <accessibility>false</accessibility>
            <script />
            <verbose>false</verbose>
            <skip_known_issues>true</skip_known_issues>
        </systemPropertyVariables>
    </configuration>
</plugin>
```

```shell
mvn test -Dverbose=true -Dtest=BshScriptTestCase
```

This does nothing for speed of course, java has its hands full keeping things running, any less resources and we start getting out of memory errors. The first of which comes from the super import `import *;` which stumbles in BshClassPath. We can probably try and squeeze more but it doesn't break per se, there simply isn't anymore room to create new stuff.

I cleaned up BshClasspath, mostly applying generic types to make it easier to read. Made a few tweaks and there is probably more we can do for this but I am confident it is not the cause for any of the issues. Improved the coverage too so it should be on par now.

Circling back to the loader changed listeners I discovered this snippet on BSHType:

https://github.com/beanshell/beanshell/blob/b14e762c8904c088ca4a1e6b3dcadd629cde4b43/src/main/java/bsh/BSHType.java#L175-L179

It  appears to be from the first commit and I am not sure whether it is only theoretical or based on actual issues. The comments it refers to I found on SimpleNode:

https://github.com/beanshell/beanshell/blob/b14e762c8904c088ca4a1e6b3dcadd629cde4b43/src/main/java/bsh/SimpleNode.java#L31-L47

It is true that we reiterate over the nodes, and certain interpreted results are cached as instance variables. We cannot cache everything or it will stop appearing to execute. As for scripted types, already interpreted, and executed at least once, I cannot imagine what would entice them to change on the fly, regardless of actions on the classpath. If the types are wrong then I would imagine restarting the script would be the course of action, ensuring that the classpath is appropriate before interpretation and execution.

Anyway, unsubscribing from the publisher does not break any tests, and halves the number of listeners to announce to from the class manager. The "cached" types state are not thread safe and if they were to change on the fly it could only spell disaster. Unfortunately this is also only theoretical and we will need to test it in the wild. Commented out for now to see what explodes.

Commit log message
```
low memory unit tests

optimised unit test memory usage, fixed deprecation fixed two incomplete tests, added coverage for BshClassPath return exit status in exec command as per #109
fix deprecated File.toURL in addClassPath command
Cleaned up BshClassPath with minor refactoring
Unsubscribe BSHType from class loader changed broadcasts
```