### PR TITLE
Fix the problem with operator precedence (#590)

### DIFF
--- a/src/main/jjtree/bsh.jjt
+++ b/src/main/jjtree/bsh.jjt
@@ -775,62 +775,164 @@ int AssignmentOperator() :
     }
 }
 
+/*
+ * Here follows the productions for Java expressions.
+ * JavaCC implements operator precedence using the cascade of
+ * productions.  It is important to maintain these as separate
+ * independent productions in the reverse sequence of the order of
+ * precedence. Do not flatten these in to fewer productions in an
+ * attempt to make the parser go faster because:
+ * - it will lose all the BEMDAS/PEMDAS order of operations.
+ * - it probably wont go faster.  Don't forget JavaCC will emit java
+ * code that still has all of the conditional tests.  All flattening
+ * will do is rearrange them in to a different order.  The java code 
+ * will be compiled, jitted and inlined by c2 so you wont even know
+ * what the performance impact is unless you do micro benchmarks.
+ */
 void ConditionalExpression() :
-{ Token t; }
+{ }
 {
-  RelationalExpression() (  "?" ConditionalExpression() ":" ConditionalExpression() #TernaryExpression(3)
-  |
-  ( (t="||" | t="@or" | t="&&" | t="@and") RelationalExpression()
-        { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
-  )
+  ConditionalOrExpression() [ <HOOK> Expression() <COLON> ConditionalExpression()
+    #TernaryExpression(3) ]
+}
+
+void ConditionalOrExpression() :
+{ Token t=null; }
+{
+  ConditionalAndExpression()
+  ( ( t = <BOOL_OR> | t = <BOOL_ORX> )
+    ConditionalAndExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void ConditionalAndExpression() :
+{ Token t=null; }
+{
+  InclusiveOrExpression()
+  ( ( t = <BOOL_AND> | t = <BOOL_ANDX> )
+    InclusiveOrExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void InclusiveOrExpression() :
+{ Token t=null; }
+{
+  ExclusiveOrExpression()
+  ( ( t = <BIT_OR> | t = <BIT_ORX> )
+    ExclusiveOrExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void ExclusiveOrExpression() :
+{ Token t=null; }
+{
+   AndExpression()
+      ( ( t = <XOR> | t = <XORX> )
+        AndExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void AndExpression() :
+{ Token t=null; }
+{
+   EqualityExpression()
+  (( t = <BIT_AND> | t = <BIT_ANDX> )
+    EqualityExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void EqualityExpression() :
+{ Token t = null; }
+{
+  InstanceOfExpression()
+     (LOOKAHEAD(2) ( t = <EQ> | t= <NE> )
+      InstanceOfExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2)
+  )*
+}
+
+void InstanceOfExpression() :
+{ Token t = null; }
+{
+  RelationalExpression()
+  [t = <INSTANCEOF> Type() { jjtThis.kind = t.kind; } #BinaryExpression(2) ]
 }
 
 void RelationalExpression() :
-{ Token t; }
+{ Token t = null; }
 {
-  BinaryExpression() (
-    t="instanceof" Type() { jjtThis.kind = t.kind; } #BinaryExpression(2)
-    |
-    ((t="==" | t="!=" | t="<" | t="@lt" | t=">" | t="@gt" | t="<="
-            | t="@lteq" | t=">=" | t="@gteq") BinaryExpression()
-        { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
-  )
+  ShiftExpression()
+  (( t = <LT> | t = <LTX> | t = <GT> | t = <GTX> |
+      t = <LE> | t = <LEX> | t = <GE> | t = <GEX> )
+  ShiftExpression()
+  { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
 }
 
-void BinaryExpression() :
-{ Token t; }
+void ShiftExpression() :
+{ Token t = null; }
 {
-  UnaryExpression() ( (t="+" | t="-" | t="*" | t="/" | t="%" | t="@mod"
-        | t="**" | t="@pow" | t="<<" | t="@left_shift" | t=">>"
-        | t="@right_shift" | t=">>>" | t="@right_unsigned_shift" | t="|"
-        | t="@bitwise_or" | t="^" | t="@bitwise_xor" | t="&"
-        | t="@bitwise_and")
-    UnaryExpression() { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+  AdditiveExpression()
+  (( t = <LSHIFT> | t = <LSHIFTX> | t = <RSIGNEDSHIFT> |
+      t = <RSIGNEDSHIFTX> | t = <RUNSIGNEDSHIFT> | t = <RUNSIGNEDSHIFTX> )
+  AdditiveExpression()
+  { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void AdditiveExpression() :
+{ Token t = null; }
+{
+  MultiplicativeExpression()
+   ( ( t = <PLUS> | t = <MINUS> )
+  MultiplicativeExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2)  )*
+}
+
+void MultiplicativeExpression() :
+{ Token t = null; }
+{
+  PowerExpression()
+     (( t = <STAR> | t = <SLASH> )
+      PowerExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
+}
+
+void PowerExpression() :
+{ Token t = null; }
+{
+  UnaryExpression()
+     (( t = <MOD> | t = <MODX> |
+        t = <POWER> | t = <POWERX> )
+      UnaryExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
 }
 
 void UnaryExpression() :
-{ Token t; }
+{ Token t = null; }
 {
-  (t="+" | t="-" | t="~" | t="!") UnaryExpression()
+   // prefix sign
+  ( t = <PLUS> | t = <MINUS> | t = <TILDE> | t = <BANG> ) UnaryExpression()
     { jjtThis.kind = t.kind; } #UnaryExpression(1)
 |
-  (t="++" | t="--") PrimaryExpression()
+  // prefix incr/decr
+  (t = <INCR> | t = <DECR>) PrimaryExpression()
     { jjtThis.kind = t.kind; } #UnaryExpression(1)
 |
+  // cast
   LOOKAHEAD( CastLookahead() ) CastExpression()
 |
-  PrimaryExpression() [ (t="++" | t="--")
+  // postfix incr/decr
+  PrimaryExpression() [ (t = <INCR> | t = <DECR>)
     { jjtThis.kind = t.kind; jjtThis.postfix = true; } #UnaryExpression(1) ]
 }
 
-// This production is to determine lookahead only.
-void CastLookahead() :
-{ }
+// This production only looks ahead to see if the next matches a cast.
+void CastLookahead() : { }
 {
-  "(" ( PrimitiveType()
-  | AmbiguousName() ( "[" | ")"
-    ("~" | "!" | "(" | <IDENTIFIER> | "new" | Literal() | ArrayDimensions()))
-  )
+  LOOKAHEAD(2) <LPAREN> PrimitiveType()
+|
+  LOOKAHEAD( <LPAREN> AmbiguousName() <LBRACKET> ) <LPAREN> AmbiguousName() <LBRACKET> <RBRACKET>
+|
+ <LPAREN> AmbiguousName() <RPAREN> ( <TILDE> | <BANG> | <LPAREN> | <IDENTIFIER> | <NEW> | Literal() | ArrayDimensions() )
 }
 
 void CastExpression() #CastExpression :

--- a/src/main/jjtree/bsh.jjt
+++ b/src/main/jjtree/bsh.jjt
@@ -776,18 +776,13 @@ int AssignmentOperator() :
 }
 
 /*
- * Here follows the productions for Java expressions.
+ * Here follows the productions for Java operators.
  * JavaCC implements operator precedence using the cascade of
  * productions.  It is important to maintain these as separate
  * independent productions in the reverse sequence of the order of
  * precedence. Do not flatten these in to fewer productions in an
- * attempt to make the parser go faster because:
- * - it will lose all the BEMDAS/PEMDAS order of operations.
- * - it probably wont go faster.  Don't forget JavaCC will emit java
- * code that still has all of the conditional tests.  All flattening
- * will do is rearrange them in to a different order.  The java code 
- * will be compiled, jitted and inlined by c2 so you wont even know
- * what the performance impact is unless you do micro benchmarks.
+ * attempt to make the parser go faster because it will lose all
+ * the BEMDAS/PEMDAS order of operations.
  */
 void ConditionalExpression() :
 { }
@@ -891,7 +886,7 @@ void MultiplicativeExpression() :
 { Token t = null; }
 {
   PowerExpression()
-     (( t = <STAR> | t = <SLASH> )
+     (( t = <STAR> | t = <SLASH> | t = <MOD> | t = <MODX> )
       PowerExpression()
     { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
 }
@@ -900,8 +895,7 @@ void PowerExpression() :
 { Token t = null; }
 {
   UnaryExpression()
-     (( t = <MOD> | t = <MODX> |
-        t = <POWER> | t = <POWERX> )
+     (( t = <POWER> | t = <POWERX> )
       UnaryExpression()
     { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
 }

--- a/src/test/java/bsh/OperatorPrecedenceTest.java
+++ b/src/test/java/bsh/OperatorPrecedenceTest.java
@@ -83,7 +83,7 @@ public class OperatorPrecedenceTest {
 
        // mult/mod
        assertEquals("2*5%3", i.eval("2*5%3"), (int)(2*5%3));
-      
+
        // mod/power
        assertEquals("5%3**4", i.eval("5%3**4"), (int)(5%Math.pow(3,4)));
        assertEquals("5**3%4", i.eval("5**3%4"), (int)(Math.pow(5,3)%4));
@@ -98,4 +98,3 @@ public class OperatorPrecedenceTest {
                     true && false ? true : true && false ? true : false);
     }
 }
-

--- a/src/test/java/bsh/OperatorPrecedenceTest.java
+++ b/src/test/java/bsh/OperatorPrecedenceTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 public class OperatorPrecedenceTest {
 
    private Interpreter i = new Interpreter();
-   
+
     @Test
     public void issue_568() throws Exception {
 
@@ -76,11 +76,11 @@ public class OperatorPrecedenceTest {
        j=2;
        assertEquals("+2--", i.eval("j=2;+j--"), +j--);
        assertEquals("j", i.eval("j;"), j);
-       
+
        double[] k= new double[1];
        assertEquals("-k[0]++", i.eval("k=new double[1];-k[0]++"), -k[0]++);
        assertEquals("k[0]", i.eval("k[0];"), k[0]);
-       
+
 
        // mod/power
        assertEquals("5%3**4", i.eval("5%3**4"), (int)(Math.pow(5%3,4)));

--- a/src/test/java/bsh/OperatorPrecedenceTest.java
+++ b/src/test/java/bsh/OperatorPrecedenceTest.java
@@ -81,9 +81,11 @@ public class OperatorPrecedenceTest {
        assertEquals("-k[0]++", i.eval("k=new double[1];-k[0]++"), -k[0]++);
        assertEquals("k[0]", i.eval("k[0];"), k[0]);
 
-
+       // mult/mod
+       assertEquals("2*5%3", i.eval("2*5%3"), (int)(2*5%3));
+      
        // mod/power
-       assertEquals("5%3**4", i.eval("5%3**4"), (int)(Math.pow(5%3,4)));
+       assertEquals("5%3**4", i.eval("5%3**4"), (int)(5%Math.pow(3,4)));
        assertEquals("5**3%4", i.eval("5**3%4"), (int)(Math.pow(5,3)%4));
 
        // casting

--- a/src/test/java/bsh/OperatorPrecedenceTest.java
+++ b/src/test/java/bsh/OperatorPrecedenceTest.java
@@ -91,6 +91,11 @@ public class OperatorPrecedenceTest {
        // casting
        assertEquals("(int)(5.0/2.0)", i.eval("(int)(5.0/2.0)"), (int)(5.0/2.0));
        assertEquals("(int)-(5.0/2.0)", i.eval("(int)-(5.0/2.0)"), (int)-(5.0/2.0));
+
+       // Trinary
+       assertEquals("true && false ? true : true && false ? true : false;",
+                    i.eval("true && false ? true : true && false ? true : false;"),
+                    true && false ? true : true && false ? true : false);
     }
 }
 

--- a/src/test/java/bsh/OperatorPrecedenceTest.java
+++ b/src/test/java/bsh/OperatorPrecedenceTest.java
@@ -1,0 +1,94 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+/****************************************************************************/
+
+package bsh;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Check that the order of operator evaluation is identical to Java.
+ */
+public class OperatorPrecedenceTest {
+
+   private Interpreter i = new Interpreter();
+   
+    @Test
+    public void issue_568() throws Exception {
+
+       // Issue #568
+       assertEquals("true || false ? \"True\" : \"False\"", i.eval("true || false ? \"True\" : \"False\""), true || false ? "True" : "False");
+    }
+
+    @Test
+    public void issue_590() throws Exception {
+
+       // Issue #590
+       assertEquals("1000+60*0", i.eval("1000+60*0"), 1000+60*0);
+    }
+
+    @Test
+    public void precedence_tests() throws Exception {
+
+       assertEquals("1+1", i.eval("1+1"), 1+1);
+
+       assertEquals("false?true?1:2:false?3:4", i.eval("false?true?1:2:false?3:4"), false?true?1:2:false?3:4);
+
+       assertEquals("true||false&&false||false", i.eval("true||false&&false||false"), true||false&&false||false);
+       assertEquals("true||false&&false||false?1:2", i.eval("true||false&&false||false?1:2"), true||false&&false||false?1:2);
+       assertEquals("1==0||false&&false||false?1:2", i.eval("1==0||false&&false||false?1:2"), 1==0||false&&false||false?1:2);
+       assertEquals("1==1||false&&false||false?1:2", i.eval("1==1||false&&false||false?1:2"), 1==1||false&&false||false?1:2);
+       assertEquals("false||1<0==false||false?1:2", i.eval("false||1<0==false||false?1:2"), false||1<0==false||false?1:2);
+       assertEquals("false||1>=0==false||false?1:2", i.eval("false||1>=0==false||false?1:2"), false||1>=0==false||false?1:2);
+       assertEquals("false||1+1==2==false||false?1:2", i.eval("false||1+1==2==false||false?1:2"), false||1+1==2==false||false?1:2);
+       assertEquals("1+2*3<<2", i.eval("1+2*3<<2"), 1+2*3<<2);
+       assertEquals("false||1+2*3<<2==28==false||false?1:2", i.eval("false||1+2*3<<2==28==false||false?1:2"), false||1+2*3<<2==28==false||false?1:2);
+       assertEquals("31/7/2", i.eval("31/7/2"), 31/7/2);
+       assertEquals("1+31/7/2*10-5", i.eval("1+31/7/2*10-5"), 1+31/7/2*10-5);
+       assertEquals("1+31/7/2*10+ -5", i.eval("1+31/7/2*10+ -5"), 1+31/7/2*10+ -5);
+       assertEquals("- - - - -5", i.eval("- - - - -5"), - - - - -5);
+       assertEquals("- + - + -5", i.eval("- + - + -5"), - + - + -5);
+       assertEquals("\"a\"+\"b\".equals(\"b\")", i.eval("\"a\"+\"b\".equals(\"b\")"), "a"+"b".equals("b"));
+       // power
+       assertEquals("1+2*3**4", i.eval("1+2*3**4"), (int)(1+2*Math.pow(3,4)));
+       // increment
+       int j=2;
+       assertEquals("-2++", i.eval("j=2;-j++"), -j++);
+       assertEquals("j", i.eval("j;"), j);
+       j=2;
+       assertEquals("+2--", i.eval("j=2;+j--"), +j--);
+       assertEquals("j", i.eval("j;"), j);
+       
+       double[] k= new double[1];
+       assertEquals("-k[0]++", i.eval("k=new double[1];-k[0]++"), -k[0]++);
+       assertEquals("k[0]", i.eval("k[0];"), k[0]);
+       
+
+       // mod/power
+       assertEquals("5%3**4", i.eval("5%3**4"), (int)(Math.pow(5%3,4)));
+       assertEquals("5**3%4", i.eval("5**3%4"), (int)(Math.pow(5,3)%4));
+
+       // casting
+       assertEquals("(int)(5.0/2.0)", i.eval("(int)(5.0/2.0)"), (int)(5.0/2.0));
+       assertEquals("(int)-(5.0/2.0)", i.eval("(int)-(5.0/2.0)"), (int)-(5.0/2.0));
+    }
+}
+

--- a/src/test/resources/test-scripts/operators.bsh
+++ b/src/test/resources/test-scripts/operators.bsh
@@ -1,6 +1,7 @@
 #!/bin/java bsh.Interpreter
 
 source("TestHarness.bsh");
+source("Assert.bsh");
 
 /**
     I'm just taking a shotgun approach here... we need better tests.
@@ -48,6 +49,11 @@ assert( "foo" != void );
 assert( isEvalError("void instanceof 5") );
 assert( isEvalError("new Object() instanceof void") );
 assert( isEvalError("null instanceof void") );
+
+// related to #390
+assertEquals("( true ? false : ( false ? true : false ))", ( true ? false : ( false ? true : false )), false);
+assertEquals("( true && false ? true : ( true && false ? true : false ))", ( true && false ? true : ( true && false ? true : false )), false);
+assertEquals("(( true && false ) ? true : (( true && false ) ? false : true ))", (( true && false ) ? true : (( true && false ) ? false : true )), true);
 
 /*
     Uncomment these if we start enforcing operations on primitive/non-prim


### PR DESCRIPTION
- set up productions in reverse order of precedence
- split productions that contain operators of different precedence
- join productions that have operators of similar precedence
- use tokens instead of strings
- add test case
- minor cleanup

This should fix the problem with 1+2*3=9 as noted in #590 and probably elsewhere.  Simply reverting the patch that broke operator precedence wasn't acceptable, and with no one else stepping up I went ahead and redid this.  So basically this RP is almost the same as before but fixes mod/power precedence.  I retained the reduction of productions in the unary expression and elimination of one lookahead from the cast expression.  Tokens are used instead of strings because a one point this was the strong recommendation for better performance from the javacc documentation.  The test case is a work in progress.