### PR TITLE
Fix for #655 and #659

### DIFF
--- a/src/main/java/bsh/BSHAllocationExpression.java
+++ b/src/main/java/bsh/BSHAllocationExpression.java
@@ -212,8 +212,11 @@ class BSHAllocationExpression extends SimpleNode
         NameSpace namespace = callstack.top();
         NameSpace local = new NameSpace(namespace, "AnonymousBlock");
         callstack.push(local);
-        body.eval( callstack, interpreter, true/*overrideNamespace*/ );
-        callstack.pop();
+        try {
+           body.eval( callstack, interpreter, true/*overrideNamespace*/ );
+        } finally {
+           callstack.pop();
+        }
         // statical import fields from the interface so that code inside
         // can refer to the fields directly (e.g. HEIGHT)
         local.importStatic( type );

--- a/src/main/java/bsh/Name.java
+++ b/src/main/java/bsh/Name.java
@@ -899,13 +899,15 @@ class Name implements java.io.Serializable
                 "Local method invocation", callerInfo, callstack );
         }
 
-        // If defined, invoke it
-        if ( meth != null ) {
-            boolean overrideChild = !namespace.isMethod
-                    && namespace.isChildOf(meth.declaringNameSpace);
-
-            return meth.invoke( args, interpreter, callstack, callerInfo, overrideChild );
-        }
+        /*
+         * If method has been found invoke it.  Note it is important to
+         * not pass in the overrideChild flag because method invocations
+         * need to have a new namespace parented by the declaring
+         * namespace pushed on to the stack.  This is the basis for
+         * scripted objects and how closures are implemented.
+         */
+        if ( meth != null )
+           return meth.invoke( args, interpreter, callstack, callerInfo);
 
         // Look for a BeanShell command
         return namespace.invokeCommand(methodName, args, interpreter, callstack, callerInfo);

--- a/src/test/java/bsh/Namespace_Chaining_Test.java
+++ b/src/test/java/bsh/Namespace_Chaining_Test.java
@@ -64,7 +64,11 @@ public class Namespace_Chaining_Test {
         root.eval("int foo() { return bar; }");
 
         assertEquals(42, root.eval("foo();"));
-        assertEquals(4711, child.eval("foo();"));
+        /*
+         * foo is a closure and will look up names in it's declaring namespace,
+         * not in the child namespace
+         */
+        assertEquals(42, child.eval("foo();"));
     }
 
     @Test
@@ -84,9 +88,13 @@ public class Namespace_Chaining_Test {
         // Method foo declared in parent namespace returns bar
         root.eval("int foo() { return bar; }");
 
+        /*
+         * foo is a closure and will look up names in it's declaring namespace,
+         * not in the child namespaces
+         */
         assertEquals(42, root.eval("foo();"));
-        assertEquals(4711, child.eval("foo();"));
-        assertEquals(5, child2.eval("foo();"));
+        assertEquals(42, child.eval("foo();"));
+        assertEquals(42, child2.eval("foo();"));
     }
 
     @Test

--- a/src/test/resources/test-scripts/eval.bsh
+++ b/src/test/resources/test-scripts/eval.bsh
@@ -36,15 +36,52 @@ assert(b==6); // sanity check
 assert(s.a==5);
 assert(a==6);
 
-// block namespace calling method twice #508
-y = 22;
+
+
+/*
+ * Test that eval can look up and set in the parent global namespace.
+ * Eval is performed with it's own namespace, but it will share the
+ * global namespace as a parent.  In order to communicate between eval and
+ * current context the only common namespace is the global namespace.
+ * 
+ * Test that this works by setting a value in the global namespace in
+ * this intepreter, then having the eval read and set another variable
+ * in the global namespace. 
+ *
+ * Need to explicitly use the global namespace here the first time
+ * the variables are referenced because the test framework is running
+ * in it's own namespace and new variables will be local by default.
+ * After they are set global the first time then lookups will work correctly.
+ *
+ * Related to #508.  Fixed with #659
+ */
+// set y in global not local
+global.y = 22;
+// assign y to yval
 try { eval("yval=y;"); }
-catch (e) { assert(false); }
+catch (e) { System.err.println(e);assert(false); }
+// assert that the are equal by looking up from current
 assert(yval==y);
+
+// Repeated lookup should work
 yval=0;
 try { eval("yval=y;"); }
-catch (e) { assert(false); }
+catch (e) { System.err.println(e);assert(false); }
 assert(yval==22);
 
+// remove unused variables from global namespace
+unset("y");
+unset("yval");
+
+// Test that eval'ed variables in blocks are not are seen in global
+// make sure x does not exist at start
+assert(x == void);
+try { eval("{x=55;}"); }
+catch (e) { System.err.println(e);assert(false); }
+assert(x == void);
+try { eval("{global.x=55;}"); }
+catch (e) { System.err.println(e);assert(false); }
+assert(x == 55);
+unset("x");
 
 complete();

--- a/src/test/resources/test-scripts/scripted_object.bsh
+++ b/src/test/resources/test-scripts/scripted_object.bsh
@@ -1,0 +1,39 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+
+/*
+ * Test that variable lookups in scripted objects work correctly
+ * Related to #659
+ */
+
+test1(String c) {
+   return this;
+}
+
+container() {
+   ylds = new ArrayList();
+   return this;
+}
+
+Object c = null;
+{
+   {
+      c = container();
+   }
+   c.ylds.add(test1("hello"));
+}
+assert("hello".equals(c.ylds.get(0).c));
+Object d = null;
+{
+   {
+      d = container();
+   }
+   d.ylds.add(test1("goodbye"));
+}
+assert(c.ylds.size() == 1);
+assert("hello".equals(c.ylds.get(0).c));
+assert(d.ylds.size() == 1);
+assert("goodbye".equals(d.ylds.get(0).c));
+
+complete();

--- a/src/test/resources/test-scripts/scripted_object.bsh
+++ b/src/test/resources/test-scripts/scripted_object.bsh
@@ -19,6 +19,15 @@ container() {
 Object c = null;
 {
    {
+      Object c = container();
+      c.ylds.add(test1("hello"));
+      assert("hello".equals(c.ylds.get(0).c));
+   }
+   assert(c == null);
+}
+
+{
+   {
       c = container();
    }
    c.ylds.add(test1("hello"));


### PR DESCRIPTION
Here is a patch that works for me for fixing #655 and also #659.

There isn't a lot in this patch, really the significant bits are only two relatively small changes.  That plus wrapping try-finally around a few method calls, reformatting the code to not make my eyes bleed (well, you might not like my style any better), fixing a data race issue, and adjusting the tests to the newly expected results.

I expect that these changes will be controversial and probably not acceptable, but I am putting this out here to show you what is working for me.  If leads to a productive discussion that's great.  If you don't like this approach that's ok too, at least I have shown you something that makes a couple of problems go away.

### Fixing scripted object/variable confusion (#659)
The first change I have already discussed and that is in the `Name` class [to sure that invokeMethod does not set overrideChild flag to true](https://github.com/beanshell/beanshell/blob/a288337a9ae6ba8329420ca9117fb791f120889f/src/main/java/bsh/Name.java#L910).  As I discussed elsewhere my analysis leads me to believe (I'm hedging here because I am open to be proven wrong) that method invocations always require that a new namespace be allocated with the declaring namespace as the parent, and this gets swapped on to the top of the callstack.  The body of the scripted object will be run using this new namespace.  When the methods returns `this` to the caller it will be backed by this fresh namespace.  For that reason the `overrideChild` flag must always be false.  I do not think that this is too controversial.

This change will alter the name resolution semantics for closures back to what they were in BeanShell 2.*.   These semantics got changed with de15ce30c.   In previous beanshell versions scripted objects resolved names from with the scripted object first and then through the declaring namespace parent.  The scope of name resolution is then fixed for all all objects created by the method.  de15ce30c changed this so that name resolution was via the top of current call stack. There are two problems here:
1. since names are set in the namespace on the top of the callstack they are not isolated.  One scripted object will clobber the values of the previous object.
2. since the namespace at the top of the current callstack is used for name and value resolution this means that the scripted objects will potentially lookup different variables and values when called from contexts.  

There is nothing illegal about the second point, but it is a significant change from beanshell 2.* and I think it is worth a discussion before breaking backward compatibility.  My opinion is that a) I liked the original way much better because it encapsulates values better; and b) I don't like breaking compatibility.  This new way opens up too many possibilities for variables to be overridden in unexpected and surprising ways.  It's like leaving a loaded gun on the table.  If you need to use different values in different contexts then pass them in as parameters, easy-peasy. Don't just automagically absorb them from enclosing namespaces, this new way is too surprising and difficult to reason about.  It allows third party objects to change how your objects work by setting local variables that will override the closures.  If beanshell were a popular scripting language this would be seen as a security hole not a feature.

So this change is [basically a one-liner](https://github.com/beanshell/beanshell/blob/a288337a9ae6ba8329420ca9117fb791f120889f/src/main/java/bsh/Name.java#L910), plus changing the test cases to reflect that variable resolution is via the declaring namespace, not the top of the current callstack

### Disappearing variables (#655)
This problem is that in a long running data processing scripts variables would mysteriously become undefined, when for they previous x00,000 iterations they had worked correctly (read more about this in #655).  My analysis of the problem is described below, and the solution I am using is basically [a three-liner](https://github.com/beanshell/beanshell/blob/a288337a9ae6ba8329420ca9117fb791f120889f/src/main/java/bsh/BSHBlock.java#L143).   My solution works for me, and I think my analysis is correct but I am going to hedge here again and say I am open to being proven wrong.

Class BSHBlock is using the ReferenceCache to keep hold of and recycle NameSpace objects.  The current top namespace is the key that is used to access the subordinate namespace's in the cache.   Instead of allocating a new NameSpace object as required, and then allowing it to be disposed of by the GC when it isn't used anymore, the ReferenceCache will create a new NameSpace when there is a miss in the cache, and afterwards will recycle the previously initialized object.  Every time the NameSpace object is finished being used in BSHBlock some of the internal state of the NameSpace is reinitialized.  The cache uses WeakReferences so cache entries can be reaped by the GC, but presumably the hot ones will stay around to a while.  This method depends on GC performance patterns that have no guarantees.

I suppose the ReferenceCache is being used to improve upon the allocation/gc costs of using `new` every time.  Do I understand this right?

If I am correct in how I understand this, then the ReferenceCache will return the same subordinate namespace object for a given namespace.  If three scripted object are manufactured within the same block, would the cache not return the same subordinate namespace for use in each of them?  This would be OK if each block execution were independent, but scripted objects might return `this`, and if recycling namespaces with the cache then wouldn't all three `this` object be backed by the same NameSpace object?  Please tell me I am wrong about this.  Anyway the empirical evidence is that this change made the disappearing variable problem go away.

As I said, my fix is [a simple three-liner](https://github.com/beanshell/beanshell/blob/a288337a9ae6ba8329420ca9117fb791f120889f/src/main/java/bsh/BSHBlock.java#L143).  Just instantiate a new NameSpace to use instead of getting a recycled one from the cache.

### Other changes
1. Make the processing of enum constants thread safe.  Previously a static List was used that potentially could have collisions from multiple threads at the same time.
2. Format and and add comments to BSHBlock.  I wanted to make sure that I understood what was going on, so I spent a bit of time on staring at the code and my OCD took over.
3. Add a few try-finally wrappers to make sure that added namespaces are removed off the stack if an exception happens.