### PR TITLE
late binding and block name space cache

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Thu Dec 15 20:58:27 SAST 2022
-build=1619
+#Wed Dec 21 23:25:32 SAST 2022
+build=1677
 release=${project.version}

--- a/src/main/java/bsh/BSHAllocationExpression.java
+++ b/src/main/java/bsh/BSHAllocationExpression.java
@@ -212,8 +212,11 @@ class BSHAllocationExpression extends SimpleNode
         NameSpace namespace = callstack.top();
         NameSpace local = new NameSpace(namespace, "AnonymousBlock");
         callstack.push(local);
-        body.eval( callstack, interpreter, true/*overrideNamespace*/ );
-        callstack.pop();
+        try {
+            body.eval( callstack, interpreter, true/*overrideNamespace*/ );
+        } finally {
+            callstack.pop();
+        }
         // statical import fields from the interface so that code inside
         // can refer to the fields directly (e.g. HEIGHT)
         local.importStatic( type );

--- a/src/main/java/bsh/BSHEnhancedForStatement.java
+++ b/src/main/java/bsh/BSHEnhancedForStatement.java
@@ -37,12 +37,14 @@ import java.util.Iterator;
  */
 class BSHEnhancedForStatement extends SimpleNode implements ParserConstants {
 
+    final int blockId;
     String varName;
     boolean isFinal = false;
 
 
     BSHEnhancedForStatement(int id) {
         super(id);
+        blockId = BlockNameSpace.blockCount.incrementAndGet();
     }
 
 
@@ -76,7 +78,8 @@ class BSHEnhancedForStatement extends SimpleNode implements ParserConstants {
         Object returnControl = Primitive.VOID;
         while ( !Thread.interrupted() && iterator.hasNext() ) {
             try {
-                BlockNameSpace eachNameSpace = new BlockNameSpace(enclosingNameSpace);
+                NameSpace eachNameSpace = BlockNameSpace.getInstance(enclosingNameSpace, blockId);
+                eachNameSpace.clear();
                 callstack.swap(eachNameSpace);
                 Object value = iterator.next();
                 if ( value == null )

--- a/src/main/java/bsh/BSHForStatement.java
+++ b/src/main/java/bsh/BSHForStatement.java
@@ -33,6 +33,7 @@ package bsh;
 */
 class BSHForStatement extends SimpleNode implements ParserConstants
 {
+    final int blockId;
     public boolean hasForInit;
     public boolean hasExpression;
     public boolean hasForUpdate;
@@ -42,7 +43,10 @@ class BSHForStatement extends SimpleNode implements ParserConstants
     private Node forUpdate;
     private Node statement;
 
-    BSHForStatement(int id) { super(id); }
+    BSHForStatement(int id) {
+        super(id);
+        blockId = BlockNameSpace.blockCount.incrementAndGet();
+    }
 
     public Object eval(CallStack callstack , Interpreter interpreter)
         throws EvalError
@@ -58,7 +62,7 @@ class BSHForStatement extends SimpleNode implements ParserConstants
             statement = jjtGetChild(i);
 
         NameSpace enclosingNameSpace= callstack.top();
-        BlockNameSpace forNameSpace = new BlockNameSpace( enclosingNameSpace );
+        NameSpace forNameSpace = new BlockNameSpace(enclosingNameSpace, blockId);
 
         /*
             Note: some interesting things are going on here.

--- a/src/main/java/bsh/BSHMethodDeclaration.java
+++ b/src/main/java/bsh/BSHMethodDeclaration.java
@@ -47,6 +47,7 @@ class BSHMethodDeclaration extends SimpleNode
     Class returnType;  // null (none), Void.TYPE, or a Class
     int numThrows = 0;
     boolean isVarArgs;
+    boolean isThisContext;
 
     BSHMethodDeclaration(int id) { super(id); }
 
@@ -74,6 +75,15 @@ class BSHMethodDeclaration extends SimpleNode
             paramsNode = (BSHFormalParameters)jjtGetChild(0);
             blockNode = (BSHBlock)jjtGetChild(1+numThrows); // skip throws
         }
+
+        if (null != blockNode && blockNode.jjtGetNumChildren() > 0) {
+            Node crnt = blockNode.jjtGetChild(blockNode.jjtGetNumChildren() - 1);
+            if (crnt instanceof BSHReturnStatement)
+                while (crnt.hasNext())
+                    if ((crnt = crnt.next()) instanceof BSHAmbiguousName)
+                        isThisContext = "this".equals(((BSHAmbiguousName)crnt).text);
+        }
+
         paramsNode.insureParsed();
         isVarArgs = paramsNode.isVarArgs;
     }
@@ -127,6 +137,7 @@ class BSHMethodDeclaration extends SimpleNode
 // look into this
 
         NameSpace namespace = callstack.top();
+        namespace.isMethod = isThisContext;
         BshMethod bshMethod = new BshMethod( this, namespace, modifiers );
 
         namespace.setMethod( bshMethod );

--- a/src/main/java/bsh/BSHTryStatement.java
+++ b/src/main/java/bsh/BSHTryStatement.java
@@ -33,11 +33,13 @@ import java.util.List;
 
 class BSHTryStatement extends SimpleNode
 {
+    final int blockId;
     BSHTryWithResources tryWithResources = null;
 
     BSHTryStatement(int id)
     {
         super(id);
+        blockId = BlockNameSpace.blockCount.incrementAndGet();
     }
 
     public Object eval( CallStack callstack, Interpreter interpreter)
@@ -145,8 +147,8 @@ class BSHTryStatement extends SimpleNode
                     // parameter and swap it on the stack after initializing it.
 
                     NameSpace enclosingNameSpace = callstack.top();
-                    BlockNameSpace cbNameSpace =
-                        new BlockNameSpace( enclosingNameSpace );
+                    BlockNameSpace cbNameSpace = (BlockNameSpace)
+                        BlockNameSpace.getInstance( enclosingNameSpace, blockId );
 
                     try {
                         if ( mcType == BSHMultiCatch.UNTYPED )

--- a/src/main/java/bsh/NameSpace.java
+++ b/src/main/java/bsh/NameSpace.java
@@ -623,6 +623,7 @@ public class NameSpace
     public Object getVariable(final String name, final boolean recurse)
             throws UtilEvalError {
         final Variable var = this.getVariableImpl(name, recurse);
+        Interpreter.debug("Get variable: ", name, " = ", var);
         return this.unwrapVariable(var);
     }
 
@@ -777,6 +778,7 @@ public class NameSpace
     public BshMethod getMethod(final String name, final Class<?>[] sig,
             final boolean declaredOnly) throws UtilEvalError {
         BshMethod method = null;
+        Interpreter.debug("Get method: ", name, " ", this );
         // Change import precedence if we are a class body/instance
         // Get import first. Enum blocks may override class methods.
         if (this.isClass && !this.isEnum && !declaredOnly)
@@ -850,7 +852,7 @@ public class NameSpace
      *         errors loading a script that was found */
     public Object getCommand(final String name, final Class<?>[] argTypes,
             final Interpreter interpreter) throws UtilEvalError {
-        Interpreter.debug("getCommand: ", name);
+        Interpreter.debug("Get command: ", name);
         final BshClassManager bcm = interpreter.getClassManager();
         // loop backwards for precedence
         for (final String path : this.importedCommands) {

--- a/src/main/java/bsh/This.java
+++ b/src/main/java/bsh/This.java
@@ -127,15 +127,15 @@ public final class This implements java.io.Serializable, Runnable
     /**
         Get dynamic proxy for interface, caching those it creates.
     */
-    public Object getInterface( Class clas )
+    public Object getInterface( Class<?> clas )
     {
-        return getInterface( new Class[] { clas } );
+        return getInterface( new Class<?>[] { clas } );
     }
 
     /**
         Get dynamic proxy for interface, caching those it creates.
     */
-    public Object getInterface( Class [] ca )
+    public Object getInterface( Class<?>[] ca )
     {
         if ( interfaces == null )
             interfaces = new HashMap<Integer,Object>();
@@ -222,7 +222,7 @@ public final class This implements java.io.Serializable, Runnable
             BshMethod equalsMethod = null;
             try {
                 equalsMethod = namespace.getMethod(
-                    "equals", new Class [] { Object.class } );
+                    "equals", new Class<?>[] { Object.class } );
             } catch ( UtilEvalError e ) {/*leave null*/ }
             if ( methodName.equals("equals" ) && equalsMethod == null ) {
                 Object obj = args[0];
@@ -236,12 +236,12 @@ public final class This implements java.io.Serializable, Runnable
             BshMethod toStringMethod = null;
             try {
                 toStringMethod =
-                    namespace.getMethod( "toString", new Class [] { } );
+                    namespace.getMethod( "toString", new Class<?>[] { } );
             } catch ( UtilEvalError e ) {/*leave null*/ }
 
             if ( methodName.equals("toString" ) && toStringMethod == null)
             {
-                Class [] ints = proxy.getClass().getInterfaces();
+                Class<?>[] ints = proxy.getClass().getInterfaces();
                 // XThis.this refers to the enclosing class instance
                 StringBuilder sb = new StringBuilder(
                     This.this.toString() + "\nimplements:" );
@@ -251,7 +251,7 @@ public final class This implements java.io.Serializable, Runnable
                 return sb.toString();
             }
 
-            Class [] paramTypes = method.getParameterTypes();
+            Class<?>[] paramTypes = method.getParameterTypes();
             return Primitive.unwrap(
                 invokeMethod( methodName, Primitive.wrap(args, paramTypes) ) );
         }

--- a/src/test/java/bsh/PreparsedScriptTest.java
+++ b/src/test/java/bsh/PreparsedScriptTest.java
@@ -69,6 +69,16 @@ public class PreparsedScriptTest {
     }
 
     @Test
+    public void return_method_invocation() throws Exception {
+        final PreparsedScript f = new PreparsedScript(script(
+                "int foo() { return bar; }",
+                "return foo();"), _classLoader);
+        assertEquals(42, f.invoke(toMap("bar", 42)));
+        assertEquals(4711,  f.invoke(toMap("bar", 4711)));
+        assertEquals(5,  f.invoke(toMap("bar", 5)));
+    }
+
+    @Test
     public void inner_class() throws Exception {
         final PreparsedScript f = new PreparsedScript(script(
                 "import javax.crypto.*;",

--- a/src/test/resources/test-scripts/eval.bsh
+++ b/src/test/resources/test-scripts/eval.bsh
@@ -36,15 +36,50 @@ assert(b==6); // sanity check
 assert(s.a==5);
 assert(a==6);
 
-// block namespace calling method twice #508
-y = 22;
+/*
+ * Test that eval can look up and set in the parent global namespace.
+ * Eval is performed with it's own namespace, but it will share the
+ * global namespace as a parent.  In order to communicate between eval and
+ * current context the only common namespace is the global namespace.
+ *
+ * Test that this works by setting a value in the global namespace in
+ * this intepreter, then having the eval read and set another variable
+ * in the global namespace.
+ *
+ * Need to explicitly use the global namespace here the first time
+ * the variables are referenced because the test framework is running
+ * in it's own namespace and new variables will be local by default.
+ * After they are set global the first time then lookups will work correctly.
+ *
+ * As reported in #508
+ */
+// set y in global not local
+global.y = 22;
+// assign y to yval
 try { eval("yval=y;"); }
-catch (e) { assert(false); }
+catch (e) { e.printStackTrace(); assert(false); }
+// assert that the variables are equal by looking up from current
 assert(yval==y);
+
+// Repeated lookup should work
 yval=0;
 try { eval("yval=y;"); }
 catch (e) { assert(false); }
 assert(yval==22);
 
+// remove unused variables from global namespace
+unset("y");
+unset("yval");
+
+// Test that eval'ed variables in blocks are not seen in global
+// make sure x does not exist at start
+assert(x == void);
+try { eval("{x=55;}"); }
+catch (e) { assert(false); }
+assert(x == void);
+try { eval("{global.x=55;}"); }
+catch (e) { assert(false); }
+assert(x == 55);
+unset("x");
 
 complete();

--- a/src/test/resources/test-scripts/late_binding.bsh
+++ b/src/test/resources/test-scripts/late_binding.bsh
@@ -1,0 +1,22 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+/** Late binding or namespace chaining support as per #676  */
+int bar = 42;
+int getBar() { return bar; }
+{
+   {
+      int bar = 4711;
+      {
+         int bar = 5;
+         assertEquals("Bind method to new declaration value", 5, getBar());
+      }
+      assertEquals("Bind method to previous declared value", 4711, getBar());
+   }
+   assertEquals("Bind method to original declared value from parent scope", 42, getBar());
+}
+assertEquals("Bind method to declared variable from mehod declared scope", 42, getBar());
+
+complete();

--- a/src/test/resources/test-scripts/scripted_object.bsh
+++ b/src/test/resources/test-scripts/scripted_object.bsh
@@ -1,0 +1,60 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+/*
+ * Test that variable lookups in scripted objects work correctly
+ * Related to #659
+ */
+
+test1(String c) {
+   return this;
+}
+
+assertEquals("This access, parameter", test1("bar").c, "bar");
+
+container() {
+   ylds = new ArrayList();
+   return this;
+}
+
+assertEquals("This access, method variable", 0, container().ylds.size());
+{
+   assertEquals("This access, method variable from block scope", 0, container().ylds.size());
+}
+
+Object c = container();
+assertThat("This access, method variable through reference", c.ylds, iterableWithSize(0));
+
+Object c = null;
+{
+   {
+      Object c = container();
+      c.ylds.add(test1("hello"));
+      assertEquals("Shadowed reference in block scope", "hello", c.ylds.get(0).c);
+   }
+   assertNull("Parent scope hidden variable retains value", c);
+}
+
+{
+   {
+      c = container();
+   }
+   c.ylds.add(test1("hello"));
+}
+assertEquals("Global reference assigned and populated in block scope", "hello", c.ylds.get(0).c);
+Object d = null;
+{
+   {
+      d = container();
+   }
+   d.ylds.add(test1("goodbye"));
+}
+assertEquals("Previous reference still accessible", "hello", c.ylds.get(0).c);
+assertThat("This access, method variable list size remains", c.ylds, iterableWithSize(1));
+assertThat("Test equality of list item", c.ylds, hasItem(c.ylds.get(0)));
+assertThat("New reference only has one item in list", d.ylds, iterableWithSize(1));
+assertEquals("New reference assigned value", "goodbye", d.ylds.get(0).c);
+
+complete();


### PR DESCRIPTION
Merge of work done at #672
Fix issues with block name space cache may help #655
Fix #659 methods returning This reference
Fix #676 with additional tests
Fixes #508 again commands to exclude namespace override 
Improve for, enhanced for, while, and try-catch use of block name spaces 
Added more debug info for methods, commands and variables 
Fixed some generics for class types
Refactored this and super implementations and addressed commented concerns