### PR TITLE
Fix cloneable support.

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Wed Dec 21 23:25:32 SAST 2022
-build=1677
+#Fri Dec 23 02:45:54 SAST 2022
+build=1852
 release=${project.version}

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -24,7 +24,6 @@
  *                                                                           *
  *****************************************************************************/
 
-
 package bsh;
 
 import java.util.stream.IntStream;
@@ -47,7 +46,7 @@ import java.lang.reflect.InvocationTargetException;
     Note: this method incorrectly caches the method structure.  It needs to
     be cleared when the classloader changes.
 */
-public class BshMethod implements Serializable {
+public class BshMethod implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 1L;
 
@@ -120,6 +119,17 @@ public class BshMethod implements Serializable {
 
         this.javaMethod = method;
         this.javaObject = object;
+    }
+
+    /** Cloneable clone method implementation, delegated to parent.
+     * {@inheritDoc} */
+    @Override
+    public BshMethod clone() {
+        BshMethod returnClone = null;
+        try {
+            returnClone = (BshMethod) super.clone();
+        } catch (CloneNotSupportedException e) { /* is cloneable */ }
+        return returnClone;
     }
 
     /**
@@ -497,6 +507,14 @@ public class BshMethod implements Serializable {
                     "Incorrect type returned from method: "
                     + name + e.getMessage(), node, callstack );
             }
+        }
+
+        // when cloning a generated class deep copy This reference #421
+        if ("clone".equals(getName())) {
+            String className = ret.getClass().getSimpleName();
+            This thiz = Reflect.getClassInstanceThis(ret, className);
+            if (null != thiz) // not a generated class instance
+                return thiz.cloneMethodImpl(callerInfo, callstack, ret);
         }
 
         return ret;

--- a/src/main/java/bsh/NameSpace.java
+++ b/src/main/java/bsh/NameSpace.java
@@ -133,14 +133,12 @@ public class NameSpace
     Object getClassInstance() throws UtilEvalError {
         if (this.classInstance != null)
             return this.classInstance;
-        if (this.classStatic != null
-        // || (getParent()!=null && getParent().classStatic != null)
-       )
+        if (this.classStatic != null)
             throw new UtilEvalError(
-                    "Can't refer to class instance from static context.");
+                "Can't refer to class instance from static context.");
         else
             throw new InterpreterError(
-                    "Can't resolve class instance 'this' in: " + this);
+                "Can't resolve class instance 'this' in: " + this);
     }
     // End instance data
 
@@ -452,6 +450,14 @@ public class NameSpace
     */
     public String [] getVariableNames() {
         return this.variables.keySet().stream().toArray(String[]::new);
+    }
+
+    /**
+        Get the variables defined in this namespace.
+        (This does not show variables in parent namespaces).
+    */
+    public Variable [] getVariables() {
+        return this.variables.values().stream().toArray(Variable[]::new);
     }
 
     /**

--- a/src/test/resources/test-scripts/cloneable.bsh
+++ b/src/test/resources/test-scripts/cloneable.bsh
@@ -1,0 +1,51 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+public class CanClone implements Cloneable {
+   String name = "original";
+
+   public Object clone() throws CloneNotSupportedException {
+       return super.clone();
+   }
+
+   String whoami() {
+       return "I am " + this + " my name is " + name;
+   }
+
+   Object getThis() {
+      return this;
+   }
+}
+
+cclne = new CanClone();
+clne = cclne.clone();
+
+assertNotEquals("Clones are not the same", cclne, clne);
+assertEquals("Clones are of the same type", cclne.getClass(), clne.getClass());
+
+assertNotEquals("Clones have different This", cclne._bshThisCanClone, clne._bshThisCanClone);
+assertNotEquals("Clones have different This namespace", cclne._bshThisCanClone.namespace, clne._bshThisCanClone.namespace);
+assertNotEquals("Clones have different whoami", cclne.whoami(), clne.whoami());
+assertNotEquals("Clones have different this", cclne.getThis(), clne.getThis());
+
+assertEquals("Clone's instance equals this", clne, clne.getThis());
+assertNotEquals("Clone's instance not equal to other clone's this", clne, cclne.getThis());
+assertThat("Clone's whoami contains instance string", clne.whoami(), containsString(clne.toString()));
+assertThat("Clone's whoami ends with name string", clne.whoami(), endsWith(clne.name));
+
+assertEquals("Clones have the same field values", cclne.name, clne.name);
+clne.name = "iClone";
+assertNotEquals("Clones can change fields independently", cclne.name, clne.name);
+assertEquals("Name is what we expect", "iClone", clne.name);
+assertThat("Name in method output", clne.whoami(), endsWith(clne.name));
+assertThat("Name still in other method output", cclne.whoami(), endsWith(cclne.name));
+cclne.name = "oClone";
+assertNotEquals("Clones can change fields independently", clne.name, cclne.name);
+assertEquals("Name is what we expect", "oClone", cclne.name);
+assertThat("Name in method output", cclne.whoami(), endsWith(cclne.name));
+assertThat("Name still in other method output", clne.whoami(), endsWith(clne.name));
+
+
+complete();

--- a/src/test/resources/test-scripts/clonethis.bsh
+++ b/src/test/resources/test-scripts/clonethis.bsh
@@ -1,0 +1,56 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+
+public class CannotClone {
+    String name = "original";
+
+    String whoami() {
+        return "I am " + this + " my name is " + name;
+    }
+
+    Object getThis() {
+       return this;
+    }
+ }
+
+ cclne = new CannotClone();
+ clne = cclne._bshThisCannotClone.clone();
+
+ assertNotEquals("Clones are not the same", cclne, clne);
+ assertEquals("Clones are of the same type", cclne.getClass(), clne.getClass());
+
+ assertNotEquals("Clones have different This", cclne._bshThisCannotClone, clne._bshThisCannotClone);
+ assertNotEquals("Clones have different This namespace", cclne._bshThisCannotClone.namespace, clne._bshThisCannotClone.namespace);
+ assertNotEquals("Clones have different whoami", cclne.whoami(), clne.whoami());
+ assertNotEquals("Clones have different this", cclne.getThis(), clne.getThis());
+
+ assertEquals("Clone's instance equals this", clne, clne.getThis());
+ assertNotEquals("Clone's instance not equal to other clone's this", clne, cclne.getThis());
+ assertThat("Clone's whoami contains instance string", clne.whoami(), containsString(clne.toString()));
+ assertThat("Clone's whoami ends with name string", clne.whoami(), endsWith(clne.name));
+
+ assertEquals("Clones have the same field values", cclne.name, clne.name);
+ clne.name = "iClone";
+ assertNotEquals("Clones can change fields independently", cclne.name, clne.name);
+ assertEquals("Name is what we expect", "iClone", clne.name);
+ assertThat("Name in method output", clne.whoami(), endsWith(clne.name));
+ assertThat("Name still in other method output", cclne.whoami(), endsWith(cclne.name));
+ cclne.name = "oClone";
+ assertNotEquals("Clones can change fields independently", clne.name, cclne.name);
+ assertEquals("Name is what we expect", "oClone", cclne.name);
+ assertThat("Name in method output", cclne.whoami(), endsWith(cclne.name));
+ assertThat("Name still in other method output", clne.whoami(), endsWith(clne.name));
+
+ // cannot create new instance without empty constructor
+
+class NoEmpty {
+    NoEmpty(no) {}
+}
+
+ne = new NoEmpty(1);
+assert(isEvalError("Unable to clone from This reference: NoEmpty", "ne._bshThisNoEmpty.clone();"));
+
+complete();


### PR DESCRIPTION
Fixes #421 which originally reported the problems with cloning scripted objects. 
Had to deep copy all the contexts and most references to finally be able to produce two independent instances after a clone. Also completed the existing attempt to implement cloning, and we now return an actual instance instead of just copied This namespace.