### PR TITLE
All just miraculously working

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Fri Dec 23 02:45:54 SAST 2022
-build=1852
+#Fri Dec 23 09:30:02 SAST 2022
+build=1893
 release=${project.version}

--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Fri Dec 23 09:30:02 SAST 2022
-build=1893
+#Mon Dec 26 11:05:42 SAST 2022
+build=1915
 release=${project.version}

--- a/src/main/java/bsh/BSHBlock.java
+++ b/src/main/java/bsh/BSHBlock.java
@@ -168,10 +168,9 @@ class BSHBlock extends SimpleNode {
         } finally {
             // Make sure we put the namespace back when we leave.
             // Clear cached block name space, contents can be gc'ed away
-            if ( !overrideNamespace ) {
-                callstack.top().clear();
+            if ( !overrideNamespace )
                 callstack.swap( enclosingNameSpace );
-            }
+
         }
         isFirst = false;
         return ret;

--- a/src/main/java/bsh/BlockNameSpace.java
+++ b/src/main/java/bsh/BlockNameSpace.java
@@ -57,7 +57,7 @@ class BlockNameSpace extends NameSpace
     public final AtomicInteger used = new AtomicInteger(1);
 
     /** Unique key for cached name spaces. */
-    private static class UniqueBlock {
+    private static final class UniqueBlock {
         NameSpace ns;
         int id;
         /** Unique block consists of a namespace and unique id.
@@ -83,7 +83,7 @@ class BlockNameSpace extends NameSpace
 
     /** Weak reference cache for reusable block namespaces */
     private static final ReferenceCache<UniqueBlock,NameSpace> blockspaces
-        = new ReferenceCache<UniqueBlock, NameSpace>(Type.Weak, Type.Weak, 4000) {
+        = new ReferenceCache<UniqueBlock, NameSpace>(Type.Soft, Type.Soft, 4000) {
             /** Create block namespace based on unique block key as required */
             protected NameSpace create(UniqueBlock key) {
                 return new BlockNameSpace(key.ns, key.id);

--- a/src/main/java/bsh/BlockNameSpace.java
+++ b/src/main/java/bsh/BlockNameSpace.java
@@ -53,6 +53,9 @@ class BlockNameSpace extends NameSpace
     /** Atomic block count of unique block instances. */
     public static final AtomicInteger blockCount = new AtomicInteger();
 
+    /** Atomic reuse count per instance. */
+    public final AtomicInteger used = new AtomicInteger(1);
+
     /** Unique key for cached name spaces. */
     private static class UniqueBlock {
         NameSpace ns;
@@ -94,7 +97,10 @@ class BlockNameSpace extends NameSpace
      * @param blockId unique id for block
      * @return new or cached instance of a unique block name space */
     public static NameSpace getInstance(NameSpace parent, int blockId ) {
-        return blockspaces.get(new UniqueBlock(parent, blockId));
+        BlockNameSpace ns = (BlockNameSpace) blockspaces.get(
+                new UniqueBlock(parent, blockId));
+        if (null != ns && 1 < ns.used.getAndIncrement()) ns.clear();
+        return ns;
     }
 
     /** Public constructor to create a non cached instance.

--- a/src/test/java/bsh/ReferenceCacheTest.java
+++ b/src/test/java/bsh/ReferenceCacheTest.java
@@ -31,6 +31,7 @@ public class ReferenceCacheTest {
 
         assertThat(cache.size(), equalTo(1));
         assertThat(cache.get("foo"), equalTo(0));
+        assertTrue(cache.remove("foo"));
         System.gc();
     }
 
@@ -56,6 +57,7 @@ public class ReferenceCacheTest {
 
         assertThat(cache.size(), equalTo(1));
         assertThat(cache.get("foo"), equalTo("bar"));
+        assertTrue(cache.remove("foo"));
         System.gc();
     }
 
@@ -67,6 +69,7 @@ public class ReferenceCacheTest {
 
         assertThat(cache.size(), equalTo(1));
         assertThat(cache.get("foo"), equalTo(0));
+        assertTrue(cache.remove("foo"));
         System.gc();
     }
 
@@ -92,6 +95,7 @@ public class ReferenceCacheTest {
 
         assertThat(cache.size(), equalTo(1));
         assertThat(cache.get("foo"), equalTo("bar"));
+        assertTrue(cache.remove("foo"));
         System.gc();
     }
 
@@ -103,6 +107,19 @@ public class ReferenceCacheTest {
 
         assertThat(cache.size(), equalTo(1));
         assertThat(cache.get("foo"), equalTo(0));
+        assertTrue(cache.remove("foo"));
+        System.gc();
+    }
+
+    @Test
+    public void weak_reference_key_gced() {
+        ReferenceCache<String,byte[]> cache = new ReferenceCache<String,byte[]>(Weak, Weak) {
+            protected byte[] create(String key) { return new byte[1024*10000]; }};
+        cache.init("foo");
+        TestUtil.cleanUp();
+        assertThat(cache.size(), equalTo(1));
+        assertArrayEquals(new byte[1024*10000], cache.get("foo"));
+        assertTrue(cache.remove("foo"));
         System.gc();
     }
 
@@ -117,6 +134,7 @@ public class ReferenceCacheTest {
         assertThat(e.getCause(), instanceOf(NullPointerException.class));
         assertThat(e.getCause().getMessage(),
             containsString("Reference cache create value may not return null."));
+        assertTrue(cache.remove("foo"));
         System.gc();
     }
 
@@ -128,6 +146,7 @@ public class ReferenceCacheTest {
 
         assertThat(cache.size(), equalTo(1));
         assertThat(cache.get("foo"), equalTo("bar"));
+        assertTrue(cache.remove("foo"));
         System.gc();
     }
 
@@ -165,11 +184,11 @@ public class ReferenceCacheTest {
         while (cnt[0]++ < 10) {
             cache.init(cnt[0]);
             System.gc();
-            assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+            assertArrayEquals(new byte[1024*100], cache.get(cnt[0]));
         }
         System.gc();
         assertNotEquals(cache.size(), cnt[0]);
-        assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+        assertArrayEquals(new byte[1024*100], cache.get(cnt[0]));
     }
 
     @Test
@@ -180,11 +199,11 @@ public class ReferenceCacheTest {
         while (cnt[0]++ < 10) {
             cache.init(cnt[0]);
             System.gc();
-            assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+            assertArrayEquals(new byte[1024*100], cache.get(cnt[0]));
         }
         System.gc();
         assertNotEquals(cache.size(), cnt[0]);
-        assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+        assertArrayEquals(new byte[1024*100], cache.get(cnt[0]));
     }
 
     @Test
@@ -195,11 +214,11 @@ public class ReferenceCacheTest {
         while (cnt[0]++ < 10) {
             cache.init(cnt[0]);
             System.gc();
-            assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+            assertArrayEquals(new byte[1024*100], cache.get(cnt[0]));
         }
         System.gc();
         assertNotEquals(cache.size(), cnt[0]);
-        assertArrayEquals(cache.get(cnt[0]), new byte[1024*100]);
+        assertArrayEquals(new byte[1024*100], cache.get(cnt[0]));
     }
 }
 

--- a/src/test/resources/test-scripts/closurescoping2.bsh
+++ b/src/test/resources/test-scripts/closurescoping2.bsh
@@ -1,0 +1,48 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+
+// JAVA anonymous class as closure
+public interface Internal {
+    int doit();
+}
+
+public class ClosureExample {
+
+    public static void main(String[] args) {
+
+        Internal doer;
+
+        {
+            int x = 4;
+            doer = new Internal() {
+                    public int doit() {
+                        return x;
+                    }
+                };
+        }
+        assert(doer.doit() == 4);
+        int x = 5;
+        assert(doer.doit() == 4);
+    }
+}
+ClosureExample.main(new String[0]);
+
+// BSH scripted class equivalent
+doer = null;
+{
+    int x = 4;
+    internal() {
+        doit() {
+            return x;
+        }
+        return this;
+    }
+    doer = internal();
+}
+
+assert(doer.doit()==4);
+x = 5;
+assert(doer.doit()==4);
+
+complete();


### PR DESCRIPTION
 I am too tired to comprehend the why, just taking the win with a smile.

Found [the explanation](https://github.com/beanshell/beanshell/pull/672#issuecomment-1355230755) for these weird closure tests that don't seem to be testing for anything specific other than lets see how obscure we can block scope and lets throw in a couple of `x` variables for style. About how it works with the revert but not on HEAD...so I tried it on.

Was as said cannot scope x, even though it is right there.

https://github.com/beanshell/beanshell/blob/b0e6811a4358ee4505a07e86d93a9e46b1eec780/src/test/resources/test-scripts/closurescoping2.bsh#L32-L44

Something reminded me that the revert patch removed the clear namespace, since everything is going to gc anyway there is no bother. But since we are clearing the blocks, perhaps that will account for the variable missing. Commented it out and everything but 2 or 3 tests, which rely on the blocks being cleared, miraculously passed.

Everything yes, all the controversies, counter proofs, long awaited defects,  and what nots, it all just works.

Figure lets leave the blocks scoped on exit since something might still want to use it later, also changed the block name space cache to soft references to help retain most recently used references, and rather clear blocks on entry if this block was used before.

Made some fixes to reference cache, added a daemon thread factory so that we can create an executor service which won't block vm from exiting, and fixed an NPE bug when de-referencing an already cleared cache value. 