### PR TITLE
Add reset interpreter method

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Mon Dec 26 11:05:42 SAST 2022
-build=1915
+#Mon Dec 26 23:27:04 SAST 2022
+build=2015
 release=${project.version}

--- a/src/main/java/bsh/BshClassManager.java
+++ b/src/main/java/bsh/BshClassManager.java
@@ -35,8 +35,6 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -335,18 +333,18 @@ public class BshClassManager {
         Note: these should probably be re-implemented with Soft references.
         (as opposed to strong or Weak)
     */
-    protected final transient Map<String,Class<?>> absoluteClassCache = new Hashtable<>();
+    protected final transient Map<String,Class<?>> absoluteClassCache = new ConcurrentHashMap<>();
     /**
         Global cache for things we know are *not* classes.
         Note: these should probably be re-implemented with Soft references.
         (as opposed to strong or Weak)
     */
-    protected final transient Set<String> absoluteNonClasses = Collections.synchronizedSet(new HashSet<>());
-    private final transient Set<String> definingClasses = Collections.synchronizedSet(new HashSet<>());
-    protected final transient Map<String,String> definingClassesBaseNames = new Hashtable<>();
+    protected final transient Set<String> absoluteNonClasses = ConcurrentHashMap.newKeySet();
+    private final transient Set<String> definingClasses =  ConcurrentHashMap.newKeySet();
+    protected final transient Map<String,String> definingClassesBaseNames = new ConcurrentHashMap<>();
 
     /** @see #associateClass( Class ) */
-    protected final transient Map<String, Class<?>> associatedClasses = new Hashtable<>();
+    protected final transient Map<String, Class<?>> associatedClasses = new ConcurrentHashMap<>();
 
     /**
         Create a new instance of the class manager.
@@ -530,6 +528,7 @@ public class BshClassManager {
     protected void clearCaches() {
         absoluteNonClasses.clear();
         absoluteClassCache.clear();
+        memberCache.clear();
     }
 
     /**

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -757,6 +757,16 @@ public class Interpreter
         return Primitive.unwrap( retVal );
     }
 
+    /** Optional method to release additional resources. The interpreter
+     * allows for multiple eval calls and therefor maintains certain state
+     * for subsequent calls. Only use this if completely done with current
+     * interpreter and desperate to clear as much resources as possible. */
+    public void reset() {
+        getClassManager().reset();
+        globalNameSpace.clear();
+        Name.clearParts();
+    }
+
     /**
         Evaluate the inputstream in this interpreter's global namespace.
     */

--- a/src/main/java/bsh/Name.java
+++ b/src/main/java/bsh/Name.java
@@ -955,6 +955,13 @@ class Name implements java.io.Serializable
             return parts;
         }
     }
+
+    static void clearParts() {
+        synchronized (Parts.PARTSCACHE) {
+            Parts.PARTSCACHE.clear();
+        }
+    }
+
     public static boolean isCompound(String value)
     {
         return countParts(value) > 1;

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -355,7 +355,7 @@ public final class Reflect {
 
         Invocable method = BshClassManager.memberCache
                 .get(clas).findMethod(name, types);
-        Interpreter.debug("resolved java method: ", method);
+        Interpreter.debug("resolved java method: ", method, " on class: ", clas);
         checkFoundStaticMethod( method, staticOnly, clas );
         return method;
     }

--- a/src/test/java/bsh/InterpreterTest.java
+++ b/src/test/java/bsh/InterpreterTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.lessThan;
 
 import org.junit.Test;
 
@@ -250,10 +251,10 @@ public class InterpreterTest {
     }
 
     @Test
-     public void set_prompt_by_interpreter() throws Exception {
-         final StringReader in = new StringReader("\n");
-         for (String P: new String[] { "abc> ", "cde# " }) {
-             try (ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {
+    public void set_prompt_by_interpreter() throws Exception {
+        final StringReader in = new StringReader("\n");
+        for (String P: new String[] { "abc> ", "cde# " }) {
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {
                 Interpreter bsh = new Interpreter(in, new PrintStream(baos),
                     new PrintStream(baos), true);
                 bsh.setExitOnEOF(false);
@@ -262,6 +263,16 @@ public class InterpreterTest {
                 assertTrue(baos.toString().contains(P));
             }
         }
-     }
+    }
+
+    @Test
+    public void reset_interpreter() throws Exception {
+        final Interpreter bsh = new Interpreter();
+        assertEquals("test123", bsh.eval("'test' + (100 + 20 + 3)"));
+        long b4 = Runtime.getRuntime().freeMemory();
+        bsh.reset();
+        System.gc();
+        assertThat(b4, lessThan(Runtime.getRuntime().freeMemory()));
+    }
 
 }

--- a/src/test/java/bsh/ReferenceCacheTest.java
+++ b/src/test/java/bsh/ReferenceCacheTest.java
@@ -114,11 +114,11 @@ public class ReferenceCacheTest {
     @Test
     public void weak_reference_key_gced() {
         ReferenceCache<String,byte[]> cache = new ReferenceCache<String,byte[]>(Weak, Weak) {
-            protected byte[] create(String key) { return new byte[1024*10000]; }};
+            protected byte[] create(String key) { return new byte[1024*1000]; }};
         cache.init("foo");
         TestUtil.cleanUp();
         assertThat(cache.size(), equalTo(1));
-        assertArrayEquals(new byte[1024*10000], cache.get("foo"));
+        assertArrayEquals(new byte[1024*1000], cache.get("foo"));
         assertTrue(cache.remove("foo"));
         System.gc();
     }


### PR DESCRIPTION
Interpreter allows for multiple `eval` calls and for this purpose certain state is kept. Added reset method to release additional resources and when completely done with interpreter. fixes #413