### PR TITLE
Implement catch OutOfMemoryError.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
         <configuration>
-          <argLine>-XX:+UseSerialGC ${surefireArgLine}</argLine>
+          <argLine>-Xmx1000M -Xms500M -XX:+UseSerialGC ${surefireArgLine}</argLine>
           <systemPropertyVariables>
             <bsh.debugClasses />
             <accessibility>false</accessibility>

--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Mon Dec 26 23:27:04 SAST 2022
-build=2015
+#Tue Dec 27 06:16:07 SAST 2022
+build=2151
 release=${project.version}

--- a/src/test/resources/test-scripts/trycatch_ome.bsh
+++ b/src/test/resources/test-scripts/trycatch_ome.bsh
@@ -1,0 +1,83 @@
+#!/bin/java bsh.Interpreter50
+/*
+ * Test OutOfMemoryError OME in try block
+ */
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+// skip this test if not within the correct heap size parameters
+assumeThat("Needs more than 480MB and less than 1000MB heap to pass",
+    Long.valueOf(Runtime.getRuntime().totalMemory()/1024/1024),
+    allOf(greaterThan(Long.valueOf(480)), lessThanOrEqualTo(Long.valueOf(700))));
+
+data = new Hashtable();
+
+// catch OutOfMemoryError check exception message
+count = 0;
+while (count++ < 3 ) try {
+    data.put(count, new byte[1024*1024*300]);
+} catch (OutOfMemoryError e) {
+    data.clear();
+    assertThat("OutOfMemoryError has message: Java heap space", e.getMessage(), containsString("Java heap space"));
+    break;
+}
+assertThat("while was aborted", count, not(equalTo(4)));
+complete();
+
+// catch Error check instance of OutOfMemoryError
+count = 0;
+while (count++ < 3 ) try {
+    data.put(count, new byte[1024*1024*300]);
+} catch (Error e) {
+    data.clear();
+    assertThat("Error is OutOfMemoryError", e, instanceOf(OutOfMemoryError.class));
+    break;
+}
+assertThat("while was aborted", count, not(equalTo(4)));
+
+// catch Throwable check instance of OutOfMemoryError
+count = 0;
+while (count++ < 3 ) try {
+    data.put(count, new byte[1024*1024*300]);
+} catch (Throwable e) {
+    data.clear();
+    assertThat("Throwable is OutOfMemoryError", e, instanceOf(OutOfMemoryError.class));
+    break;
+}
+assertThat("while was aborted", count, not(equalTo(4)));
+
+// catch untyped exception check instance of OutOfMemoryError
+count = 0;
+while (count++ < 3 ) try {
+    data.put(count, new byte[1024*1024*300]);
+} catch (e) {
+    data.clear();
+    assertThat("Untyped exception is OutOfMemoryError", e, instanceOf(OutOfMemoryError.class));
+    break;
+}
+assertThat("while was aborted", count, not(equalTo(4)));
+
+// handle OutOfMemoryError process all records
+putIt(count) {
+    try {
+        data.put(count, new byte[1024*1024*300]);
+    } catch (OutOfMemoryError e) {
+        data.clear();
+        putIt(count);
+    }
+}
+count = 0;
+while (count++ < 3)
+    putIt(count);
+assertThat("OutOfMemoryError was handled all records processed", count, equalTo(4));
+
+// expect EvalError with cause OutOfMemoryError if we don't catch the try block
+count = 0;
+assert(isEvalError("OutOfMemoryError: Java heap space", "while (count++ < 3) try { data.put(count, new byte[1024*1024*300]); } finally {}"));
+
+// expect EvalError with cause OutOfMemoryError if we catch RuntimeException
+count = 0;
+assert(isEvalError("OutOfMemoryError: Java heap space", "while (count++ < 3) try { data.put(count, new byte[1024*1024*300]); } catch (RuntimeException e) {}"));
+
+complete();

--- a/src/test/resources/test-scripts/tryreturn.bsh
+++ b/src/test/resources/test-scripts/tryreturn.bsh
@@ -10,13 +10,9 @@ int fn() {
     try {
         return 1;
     } finally {}
-//    print("shouldn't get here, but does");  // only before bug was fixed
-    2;
+    //print("shouldn't get here, but does");  // only before bug was fixed
+    assert(false);
 }
-
-
-
-
 
 // This succeeds and it should succeed.
 assert( fn() == 1  );


### PR DESCRIPTION
Fixes #369 properly handle OutOfMemoryError thrown in try blocks, caught and handled to continue processing data.