### PR TITLE
Obfuscate bsh.Primitive from script engine

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Tue Dec 27 06:16:07 SAST 2022
-build=2151
+#Tue Jan 03 20:10:15 SAST 2023
+build=2803
 release=${project.version}

--- a/src/main/java/bsh/BSHBinaryExpression.java
+++ b/src/main/java/bsh/BSHBinaryExpression.java
@@ -77,13 +77,17 @@ class BSHBinaryExpression extends SimpleNode implements ParserConstants {
             we're a boolean AND and the lhs is false.
             or we're a boolean OR and the lhs is true.
         */
-        if ( lhs == Primitive.FALSE && (kind == BOOL_AND || kind == BOOL_ANDX) )
+        if ( Primitive.FALSE.equals(lhs) && (kind == BOOL_AND || kind == BOOL_ANDX) )
             return Primitive.FALSE;
-        if ( lhs == Primitive.TRUE && (kind == BOOL_OR || kind == BOOL_ORX) )
+        if ( Primitive.TRUE.equals(lhs) && (kind == BOOL_OR || kind == BOOL_ORX || kind == ELVIS) )
             return Primitive.TRUE;
-
+        if ( Primitive.NULL != lhs && kind == NULLCOALESCE )
+            return lhs;
 
         Object rhs = jjtGetChild(1).eval(callstack, interpreter);
+
+        if ( kind == NULLCOALESCE || kind == ELVIS )
+            return rhs;
 
         // Handle null values and apply null rules.
         lhs = checkNullValues(lhs, rhs, 0, callstack);

--- a/src/main/java/bsh/BSHFormalParameter.java
+++ b/src/main/java/bsh/BSHFormalParameter.java
@@ -41,6 +41,7 @@ class BSHFormalParameter extends SimpleNode
     public Class type;
     boolean isFinal = false;
     boolean isVarArgs = false;
+    int dimensions = 0;
 
     BSHFormalParameter(int id) { super(id); }
 

--- a/src/main/java/bsh/BSHMethodInvocation.java
+++ b/src/main/java/bsh/BSHMethodInvocation.java
@@ -65,33 +65,15 @@ class BSHMethodInvocation extends SimpleNode
         Name name = nameNode.getName(namespace);
         Object[] args = getArgsNode().getArguments(callstack, interpreter);
 
-// This try/catch block is replicated is BSHPrimarySuffix... need to
-// factor out common functionality...
-// Move to Reflect?
         try {
             return name.invokeMethod( interpreter, args, callstack, this);
-        } catch ( ReflectError e ) {
+        } catch (ReflectError e) {
             throw new EvalError(
                 "Error in method invocation: " + e.getMessage(),
-                this, callstack, e );
-        } catch ( InvocationTargetException e )
-        {
-            String msg = "Method Invocation "+name;
-            Throwable te = e.getCause();
-
-            /*
-                Try to squeltch the native code stack trace if the exception
-                was caused by a reflective call back into the bsh interpreter
-                (e.g. eval() or source()
-            */
-            boolean isNative = true;
-            if ( te instanceof EvalError )
-                if ( te instanceof TargetError )
-                    isNative = ((TargetError)te).inNativeCode();
-                else
-                    isNative = false;
-
-            throw new TargetError( msg, te, this, callstack, isNative );
+                    this, callstack, e);
+        } catch (InvocationTargetException e) {
+            throw Reflect.targetErrorFromTargetException(
+                e, name.toString(), callstack, this);
         } catch ( UtilEvalError e ) {
             throw e.toEvalError( this, callstack );
         }

--- a/src/main/java/bsh/BSHType.java
+++ b/src/main/java/bsh/BSHType.java
@@ -153,7 +153,7 @@ class BSHType extends SimpleNode
                         && e.getCause() instanceof ClassNotFoundException)
                     baseType = Object.class;
                 else
-                    e.reThrow("");
+                    throw e; // roll up unhandled error
             }
 
         if ( arrayDims > 0 ) {

--- a/src/main/java/bsh/BSHTypedVariableDeclaration.java
+++ b/src/main/java/bsh/BSHTypedVariableDeclaration.java
@@ -113,7 +113,7 @@ class BSHTypedVariableDeclaration extends SimpleNode {
                 }
             }
         } catch ( EvalError e ) {
-            e.reThrow( "Typed variable declaration" );
+            throw e.reThrow( "Typed variable declaration" );
         }
         return value;
     }

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -365,7 +365,7 @@ public class BshMethod implements Serializable, Cloneable {
         int lastParamIndex = getParameterCount() - 1;
         Object varArgs = null;
         if (isVarArgs()) {
-            Class lastP = paramTypes[lastParamIndex];
+            Class<?> lastP = paramTypes[lastParamIndex];
             // Interpreter.debug("varArgs= "+name+" "+varArgs.getClass().getName());
             // Interpreter.debug("Varargs processing for "+name+" "+Arrays.toString(argValues));
             // Interpreter.debug(" parameter types "+Arrays.toString(paramTypes));

--- a/src/main/java/bsh/ClassIdentifier.java
+++ b/src/main/java/bsh/ClassIdentifier.java
@@ -23,20 +23,16 @@
  * Author of Learning Java, O'Reilly & Associates                            *
  *                                                                           *
  *****************************************************************************/
-
-
 package bsh;
+public class ClassIdentifier {
+    Class<?> clas;
 
-public class ClassIdentifier
-{
-    Class clas;
-
-    public ClassIdentifier( Class clas ) {
+    public ClassIdentifier( Class<?> clas ) {
         this.clas = clas;
     }
 
     // Can't call it getClass()
-    public Class getTargetClass() {
+    public Class<?> getTargetClass() {
         return clas;
     }
 
@@ -44,4 +40,3 @@ public class ClassIdentifier
         return "Class Identifier: "+clas.getName();
     }
 }
-

--- a/src/main/java/bsh/EvalError.java
+++ b/src/main/java/bsh/EvalError.java
@@ -79,13 +79,12 @@ public class EvalError extends Exception
     }
 
     /**
-        Re-throw the error, prepending the specified message.
+        Return the error to re-throw, prepending the specified message.
+        Method does not throw itself as this messes with the tooling.
     */
-    public void reThrow( String msg )
-        throws EvalError
-    {
+    public EvalError reThrow( String msg ) {
         prependMessage( msg );
-        throw this;
+        return this;
     }
 
     /**

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -730,14 +730,14 @@ public class Interpreter
                 // failsafe, set the Line as the origin of the error.
                 if ( e.getNode()==null )
                     e.setNode( node );
-                e.reThrow("Sourced file: "+sourceFileInfo);
+                throw e.reThrow("Sourced file: "+sourceFileInfo);
             } catch ( EvalError e) {
                 if ( DEBUG.get())
                     e.printStackTrace();
                 // failsafe, set the Line as the origin of the error.
                 if ( e.getNode()==null )
                     e.setNode( node );
-                e.reThrow( "Sourced file: "+sourceFileInfo );
+                throw e.reThrow( "Sourced file: "+sourceFileInfo );
             } catch ( Exception e) {
                 if ( DEBUG.get())
                     e.printStackTrace();

--- a/src/main/java/bsh/Invocable.java
+++ b/src/main/java/bsh/Invocable.java
@@ -163,6 +163,8 @@ public abstract class Invocable implements Member {
     /** Basic parameter collection with pulling inherited cascade chaining. */
     public ParameterType collectParamaters(Object base, Object[] params)
             throws Throwable {
+        if (getLastParameterIndex() > params.length)
+            throw new InvocationTargetException(null, "Insufficient parameters passed for method: " + getName() + Arrays.asList(getParameterTypes()));
         parameters.clear();
         for (int i = 0; i < getLastParameterIndex(); i++)
             parameters.add(coerceToType(params[i], getParameterTypes()[i]));
@@ -176,14 +178,9 @@ public abstract class Invocable implements Member {
      * @throws Throwable on cast errors */
     protected Object coerceToType(Object param, Class<?> type)
             throws Throwable {
-       if (type != Object.class) {
-          /*
-           * If type is the same or a superclass of param then
-           * there is no need to cast the object.  Issue #613
-           */
-          if (!type.isAssignableFrom(param.getClass()))
-              param = Types.castObject(param, type, Types.CAST);
-       }
+        Class<?> pClass = Types.getType(param);
+        if (null != pClass && !type.isAssignableFrom(pClass))
+            param = Types.castObject(param, type, Types.CAST);
         return Primitive.unwrap(param);
     }
 

--- a/src/main/java/bsh/Name.java
+++ b/src/main/java/bsh/Name.java
@@ -816,22 +816,11 @@ class Name implements java.io.Serializable
 
         // if we've got an object, resolve the method
         if ( !(obj instanceof ClassIdentifier) ) {
-
-            if (obj instanceof Primitive) {
-
+            if (obj instanceof Primitive)
                 if (obj == Primitive.NULL)
                     throw new UtilTargetError( new NullPointerException(
                         "Null Pointer in Method Invocation of " +methodName
                             +"() on variable: "+targetName) );
-
-                // some other primitive
-                // should avoid calling methods on primitive, as we do
-                // in Name (can't treat primitive like an object message)
-                // but the hole is useful right now.
-                Interpreter.debug(
-                    "Attempt to access method on primitive...",
-                    " allowing bsh.Primitive to peek through for debugging");
-            }
 
             // enum block members will be in namespace only
             if ( obj.getClass().isEnum() ) {

--- a/src/main/java/bsh/NameSpace.java
+++ b/src/main/java/bsh/NameSpace.java
@@ -1350,14 +1350,15 @@ public class NameSpace
      * importClass("bsh.Interpreter");
      * importClass("bsh.Capabilities");
      * importPackage("java.net");
+     * importClass("java.util.Map.Entry");
      * importPackage("java.util.function");
      * importPackage("java.util.stream");
      * importPackage("java.util.regex");
      * importPackage("java.util");
      * importPackage("java.io");
      * importPackage("java.lang");
-     * importClass("java.math.BigInteger");
-     * importClass("java.math.BigDecimal");
+     * importClass("bsh.FileReader");
+     * importPackage("java.math");
      * importCommands("/bsh/commands");
      * </pre>
      */
@@ -1377,8 +1378,7 @@ public class NameSpace
         this.importPackage("java.io");
         this.importPackage("java.lang");
         this.importClass("bsh.FileReader");
-        this.importClass("java.math.BigInteger");
-        this.importClass("java.math.BigDecimal");
+        this.importPackage("java.math");
         this.importCommands("/bsh/commands");
     }
 

--- a/src/main/java/bsh/SafeNavigate.java
+++ b/src/main/java/bsh/SafeNavigate.java
@@ -1,0 +1,28 @@
+/** Copyright 2022 Nick nickl- Lombard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+package bsh;
+
+/** Implementation of the Safe Navigate operator ?. abort on null. In
+ * order for the safe navigate operator to function, and stop evaluating
+ * further nodes, we have to throw an exception on detecting a null.
+ * This gets caught again in BSHAssignment where a null value is returned. */
+public class SafeNavigate extends RuntimeException {
+    private static final SafeNavigate abortException = new SafeNavigate();
+
+    private SafeNavigate() { }
+
+    public static SafeNavigate doAbort() {
+        return abortException;
+    }
+}

--- a/src/main/java/bsh/StringUtil.java
+++ b/src/main/java/bsh/StringUtil.java
@@ -52,7 +52,7 @@ public class StringUtil {
             ? "null"
             : value instanceof Primitive
                 ? ((Primitive) value).getType().getSimpleName()
-                : typeString(value.getClass());
+                : typeString(Types.getType(value));
     }
 
     /** Type from class to string.

--- a/src/main/java/bsh/TargetError.java
+++ b/src/main/java/bsh/TargetError.java
@@ -91,10 +91,11 @@ public final class TargetError extends EvalError
      * @param t wrapped target exception
      * @return messages unwrapped */
     private synchronized String printTargetError( Throwable t ) {
-            StringBuilder msgs = new StringBuilder(t.toString());
-            while ( null != (t = t.getCause()) )
-                msgs.append("\n").append(t.toString());
-            return msgs.toString();
+        if (null == t) return "Cause is null";
+        StringBuilder msgs = new StringBuilder(t.toString());
+        while ( null != (t = t.getCause()) )
+            msgs.append("\n").append(t.toString());
+        return msgs.toString();
     }
 
     /**

--- a/src/main/jjtree/bsh.jjt
+++ b/src/main/jjtree/bsh.jjt
@@ -34,7 +34,6 @@
 
 options {
     JAVA_UNICODE_ESCAPE=true;
-    STATIC=false;
     JDK_VERSION="1.8";
 
     MULTI=true;
@@ -202,8 +201,7 @@ public class Parser
     boolean isRegularForStatement()
     {
         int curTok = 1;
-        Token tok;
-        tok = getToken(curTok++);
+        Token tok = getToken(curTok++);
         if ( tok.kind != FOR ) return false;
         tok = getToken(curTok++);
         if ( tok.kind != LPAREN ) return false;
@@ -215,6 +213,37 @@ public class Parser
                     return false;
                 case SEMICOLON:
                     return true;
+                case EOF:
+                    return false;
+            }
+        }
+    }
+
+    /**
+        Lookahead for trailing dimensions on formal paramater.
+        Expect "[]" and then see whether we hit "," or a ")" first.
+        Abort on "=" or ";" which will indicate assignment.
+    */
+    boolean isFormalParameterDimensions()
+    {
+        int curTok = 1;
+        Token tok = getToken(curTok++);
+        if ( tok.kind != LBRACKET ) return false;
+        tok = getToken(curTok++);
+        if ( tok.kind != RBRACKET ) return false;
+        while (true)
+        {
+            tok = getToken(curTok++);
+            switch (tok.kind) {
+                case LBRACKET:
+                case RBRACKET:
+                    continue;
+                case RPAREN:
+                case COMMA:
+                    return true;
+                case ASSIGN:
+                case SEMICOLON:
+                case LBRACE:
                 case EOF:
                     return false;
             }
@@ -263,7 +292,7 @@ SKIP : /* WHITE SPACE and TYPE PARAMATERS */
     " " | "\t" | "\r" | "\f"
     | "\n"
     | < NONPRINTABLE: (["\u0000"-"\u0020", "\u0080"-"\u00ff"])+ >
-    | < TYPE_PARAMATERS: "<" ( (~[">",";","|","&","\n","\r"])* ("& "|">,")? )* ([">"])+ >
+    | < TYPE_PARAMATERS: "<" ( (~[">",";","|","&","\n","\r","="])* ("& "|">,")? )* ([">"])+ >
 }
 
 SPECIAL_TOKEN : /* COMMENTS */
@@ -280,7 +309,7 @@ SPECIAL_TOKEN : /* COMMENTS */
  /* Moved FORMAL_COMMENT to a real token.  Modified MULTI_LINE_COMMENT to not
     catch formal comments (require no star after star) */
 | <MULTI_LINE_COMMENT:
-    "/*" (~["*"])+ "*" ("*" | (~["*","/"] (~["*"])* "*"))* "/">
+    ("/***" (["*"])* | "/*") (~["*"])* "*" ("*" | (~["*","/"] (~["*"])* "*"))* "/">
 }
 
 TOKEN : /* RESERVED WORDS AND LITERALS */
@@ -288,6 +317,7 @@ TOKEN : /* RESERVED WORDS AND LITERALS */
 < ABSTRACT : "abstract" >
 | < BOOLEAN: "boolean" >
 | < BREAK: "break" >
+| < YIELD: "yield" >
 | < CLASS: "class" >
 | < BYTE: "byte" >
 | < CASE: "case" >
@@ -493,6 +523,11 @@ TOKEN : /* OPERATORS */
 | < RSIGNEDSHIFTASSIGNX: "@right_shift_assign" >
 | < RUNSIGNEDSHIFTASSIGN: ">>>=" >
 | < RUNSIGNEDSHIFTASSIGNX: "@right_unsigned_shift_assign" >
+| < ARROW: "->" >
+| < SPACESHIP: "<=>" >
+| < NULLCOALESCEASSIGN: "??=" >
+| < NULLCOALESCE: "??" >
+| < ELVIS: "?:" >
 | < HOOK: "?" >
 | < COLON: ":" >
 | < ELLIPSIS: "..." >
@@ -679,11 +714,13 @@ void FormalParameter() #FormalParameter :
   Token t;
 }
 {
-  LOOKAHEAD(2) [ "final" { jjtThis.isFinal = true; } ]
+( LOOKAHEAD(2) [ "final" { jjtThis.isFinal = true; } ]
   Type()[ <ELLIPSIS> { jjtThis.isVarArgs = true; } ]
   t=<IDENTIFIER> { jjtThis.name = t.image; }
 |
   t=<IDENTIFIER> { jjtThis.name = t.image; }
+)
+  ( LOOKAHEAD({ isFormalParameterDimensions() }) "[" "]" { jjtThis.dimensions++; } )*
 }
 
 
@@ -767,7 +804,7 @@ int AssignmentOperator() :
 {
     ( "=" | "*=" | "**=" | "@pow_assign" | "/=" | "%=" | "@mod_assign" | "+="
         | "-=" | "&=" | "@and_assign" | "^=" | "@xor_assign" | "|="
-        | "@or_assign" | "<<=" | "@left_shift_assign" | ">>="
+        | "@or_assign" | "<<=" | "@left_shift_assign" | ">>=" | "??="
         | "@right_shift_assign" | ">>>=" | "@right_unsigned_shift_assign" )
     {
         t = getToken(0);
@@ -775,20 +812,20 @@ int AssignmentOperator() :
     }
 }
 
-/*
- * Here follows the productions for Java operators.
- * JavaCC implements operator precedence using the cascade of
- * productions.  It is important to maintain these as separate
- * independent productions in the reverse sequence of the order of
- * precedence. Do not flatten these in to fewer productions in an
- * attempt to make the parser go faster because it will lose all
- * the BEMDAS/PEMDAS order of operations.
- */
 void ConditionalExpression() :
 { }
 {
-  ConditionalOrExpression() [ <HOOK> Expression() <COLON> ConditionalExpression()
+  NullCoalesceElvisSpaceShipExpression() [ <HOOK> Expression() <COLON> ConditionalExpression()
     #TernaryExpression(3) ]
+}
+
+void NullCoalesceElvisSpaceShipExpression() :
+{ Token t=null; }
+{
+  ConditionalOrExpression()
+  ( ( t = <NULLCOALESCE> | t = <ELVIS> | t = <SPACESHIP> )
+    ConditionalOrExpression()
+    { jjtThis.kind = t.kind; } #BinaryExpression(2) )*
 }
 
 void ConditionalOrExpression() :
@@ -840,7 +877,7 @@ void EqualityExpression() :
 { Token t = null; }
 {
   InstanceOfExpression()
-     (LOOKAHEAD(2) ( t = <EQ> | t= <NE> )
+     (( t = <EQ> | t= <NE> )
       InstanceOfExpression()
     { jjtThis.kind = t.kind; } #BinaryExpression(2)
   )*
@@ -982,6 +1019,14 @@ void PrimarySuffix() #PrimarySuffix :
       [ Expression() { jjtThis.hasRightIndex = true; } ]
      ( ":" { jjtThis.step = true; } [ Expression() ] )? )? "]" {
         jjtThis.operation = BSHPrimarySuffix.INDEX;
+    }
+|
+    // Safe navigate field access or method invocation
+  LOOKAHEAD(2)
+  "?." t = <IDENTIFIER> [ Arguments() ] {
+        jjtThis.operation = BSHPrimarySuffix.NAME;
+        jjtThis.field = t.image;
+        jjtThis.safeNavigate = true;
     }
 |
     // Field access or method invocation

--- a/src/main/resources/bsh/commands/print.bsh
+++ b/src/main/resources/bsh/commands/print.bsh
@@ -15,6 +15,7 @@
 import static bsh.StringUtil.valueString;
 import bsh.StringUtil;
 import bsh.Primitive;
+import bsh.Types;
 
 bsh.help.print = "usage: print( value )";
 
@@ -22,7 +23,7 @@ void print( arg )
 {
     // Other packages are known to define a String class so best practice here to disambiguate
     if ( arg instanceof java.lang.String
-            || (arg instanceof Primitive && arg.getType() == Character.TYPE)
+            || Character.class.isInstance(arg)
             || arg instanceof CharSequence )
         this.interpreter.println( java.lang.String.valueOf(arg) );
     else
@@ -36,7 +37,7 @@ String typeValueString(value) {
 String typeString(value) {
     if ( null == value || Primitive.NULL == value )
         return "null";
-    if ( value instanceof Primitive )
-        return value.getType().getSimpleName();
+    if ( Types.getType(value).isPrimitive() )
+        return Types.getType(value).getSimpleName();
     return StringUtil.typeString(value.getClass());
 }

--- a/src/test/java/bsh/InterpreterTest.java
+++ b/src/test/java/bsh/InterpreterTest.java
@@ -271,7 +271,7 @@ public class InterpreterTest {
         assertEquals("test123", bsh.eval("'test' + (100 + 20 + 3)"));
         long b4 = Runtime.getRuntime().freeMemory();
         bsh.reset();
-        System.gc();
+        TestUtil.cleanUp();
         assertThat(b4, lessThan(Runtime.getRuntime().freeMemory()));
     }
 

--- a/src/test/java/bsh/TestBshScriptEngine.java
+++ b/src/test/java/bsh/TestBshScriptEngine.java
@@ -65,7 +65,9 @@ public class TestBshScriptEngine {
         assertEquals( 42, engine.get("fooInt") );
         engine.eval("fooInt++");
         assertEquals( 43, engine.get("fooInt"));
-        assertSame( engine.eval("fooInt.getClass();"), Primitive.class );
+        assertTrue( (boolean)engine.eval("fooInt.getClass().isPrimitive();") );
+        assertSame( Integer.TYPE, engine.eval("fooInt.getClass();") );
+        assertSame( Integer.TYPE, engine.eval("fooInt.getType();") );
         assertThat( engine.getContext().getAttribute( "fooInt", ENGINE_SCOPE ),
             instanceOf( Integer.class ) );
 

--- a/src/test/java/bsh/TypesTest.java
+++ b/src/test/java/bsh/TypesTest.java
@@ -14,6 +14,7 @@
 
 package bsh;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.junit.Assert;
@@ -33,16 +34,361 @@ public class TypesTest {
     }
 
     /**
-     * Test can cast primitive to wrapper type
+     * Test cast primitive type to primitive
      * @throws Exception in case of failure
      */
     @Test
-    public void can_cast_object_primitive_to_wrapper_type() throws Exception {
+    public void cast_primitive_to_primitive_type() throws Exception {
+        Primitive casted = Primitive.castPrimitive(
+            Long.TYPE, Double.TYPE, (Primitive) Primitive.wrap(1.00D, Double.TYPE), false, Types.CAST);
+
+        Assert.assertEquals(Long.valueOf(1), casted.getValue());
+    }
+
+    /**
+     * Test cast check only primitive type to primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_check_only_primitive_to_primitive_type() throws Exception {
+        Assert.assertEquals(Types.VALID_CAST, Primitive.castPrimitive(
+            Long.TYPE, Integer.TYPE, (Primitive) Primitive.wrap(1, Integer.TYPE), true, Types.CAST));
+    }
+
+
+    /**
+     * Test assign check only primitive type to primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void assign_check_only_primitive_to_primitive_type() throws Exception {
+        Assert.assertEquals(Types.VALID_CAST, Primitive.castPrimitive(
+            Long.TYPE, Integer.TYPE, (Primitive) Primitive.wrap(1, Integer.TYPE), true, Types.ASSIGNMENT));
+    }
+
+    /**
+     * Test checx only primitive void cast invalid
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_type_primitive_void() throws Exception {
+        Assert.assertEquals(Types.INVALID_CAST, Primitive.castPrimitive(
+            Integer.class, Integer.TYPE, Primitive.VOID, true, Types.CAST));
+    }
+
+    /**
+     * Test checx only primitive void cast invalid from void type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_type_primitive_from_void() throws Exception {
+        Assert.assertEquals(Types.INVALID_CAST, Primitive.castPrimitive(
+            Integer.TYPE, Void.TYPE, Primitive.VOID, true, Types.CAST));
+    }
+
+    /**
+     * Test checx only primitive void cast invalid from boolean type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_type_primitive_from_boolean() throws Exception {
+        Assert.assertEquals(Types.INVALID_CAST, Primitive.castPrimitive(
+            Integer.TYPE, Boolean.TYPE, Primitive.VOID, true, Types.CAST));
+    }
+
+    /**
+     * Test checx only primitive void cast valid from boolean type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_check_type_primitive_from_boolean() throws Exception {
+        Assert.assertEquals(Types.VALID_CAST, Primitive.castPrimitive(
+            Boolean.TYPE, Boolean.TYPE, Primitive.VOID, true, Types.CAST));
+    }
+
+    /**
+     * Test checx only primitive void cast valid from integer type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_check_type_primitive_from_integer() throws Exception {
+        Assert.assertEquals(Types.INVALID_CAST, Primitive.castPrimitive(
+            Integer.class, Integer.TYPE, Primitive.VOID, true, Types.CAST));
+    }
+
+    /**
+     * Test primitive cast invalid from integer type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_type_primitive_from_integer() throws Exception {
+        Throwable e = Assert.assertThrows(UtilTargetError.class,
+            () -> Primitive.castPrimitive(Integer.class, Integer.TYPE,
+                Primitive.VOID,false, Types.CAST));
+        Assert.assertTrue(e.getMessage().contains("Cannot cast primitive value to object type"));
+    }
+
+    /**
+     * Test primitive cast invalid from integer to string type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_type_primitive_from_integer_to_string() throws Exception {
+        Throwable e = Assert.assertThrows(UtilEvalError.class,
+            () -> Primitive.castPrimitive(String.class, Integer.TYPE,
+                Primitive.VOID,false, Types.ASSIGNMENT));
+        Assert.assertTrue(e.getMessage().contains("Can't assign primitive value to object type"));
+    }
+
+    /**
+     * Test checx only primitive void cast valid from null type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_type_primitive_from_null() throws Exception {
+        Assert.assertEquals(Types.VALID_CAST, Primitive.castPrimitive(
+            Integer.TYPE, null, Primitive.VOID, true, Types.CAST));
+    }
+
+    /**
+     * Test checx only primitive void cast invalid assign from null type
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_type_primitive_from_null_assign() throws Exception {
+        Assert.assertEquals(Types.INVALID_CAST, Primitive.castPrimitive(
+            Integer.TYPE, null, Primitive.VOID, true, Types.ASSIGNMENT));
+    }
+
+    /**
+     * Cast strict long to byte
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_byte() throws Exception {
+        Assert.assertEquals(Byte.MAX_VALUE,
+            Primitive.castNumberStrictJava(Byte.class, (long)Byte.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict long to short
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_short() throws Exception {
+        Assert.assertEquals(Short.MAX_VALUE,
+            Primitive.castNumberStrictJava(Short.class, (long)Short.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict long to char
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_char() throws Exception {
+        Assert.assertEquals((char) Integer.MAX_VALUE,
+            Primitive.castNumberStrictJava(Character.class, (long)Integer.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict long to int
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_int() throws Exception {
+        Assert.assertEquals(Integer.MAX_VALUE,
+            Primitive.castNumberStrictJava(Integer.class, (long)Integer.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict long to long
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_long() throws Exception {
+        Assert.assertEquals(Long.MAX_VALUE,
+            Primitive.castNumberStrictJava(Long.class, Long.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict double to float
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_float() throws Exception {
+        Assert.assertEquals(Float.MAX_VALUE,
+            Primitive.castNumberStrictJava(Float.class, (double)Float.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict double to double
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_double() throws Exception {
+        Assert.assertEquals(Double.MAX_VALUE,
+            Primitive.castNumberStrictJava(Double.class, Double.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict double to big decimal
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_big_decimal() throws Exception {
+        Assert.assertEquals(BigDecimal.ZERO.setScale(1),
+            Primitive.castNumberStrictJava(BigDecimal.class, (double)0.00));
+    }
+    /**
+     * Cast strict long to byte primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_byte_primitive() throws Exception {
+        Assert.assertEquals(Byte.MAX_VALUE,
+            Primitive.castNumberStrictJava(Byte.TYPE, (long)Byte.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict long to short primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_short_primitive() throws Exception {
+        Assert.assertEquals(Short.MAX_VALUE,
+            Primitive.castNumberStrictJava(Short.TYPE, (long)Short.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict long to char primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_char_primitive() throws Exception {
+        Assert.assertEquals((char) Integer.MAX_VALUE,
+            Primitive.castNumberStrictJava(Character.TYPE, (long)Integer.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict long to int primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_int_primitive() throws Exception {
+        Assert.assertEquals(Integer.MAX_VALUE,
+            Primitive.castNumberStrictJava(Integer.TYPE, (long)Integer.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict int to long primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_long_primitive() throws Exception {
+        Assert.assertEquals((long)Integer.MAX_VALUE,
+            Primitive.castNumberStrictJava(Long.TYPE, (long)Integer.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict double to float primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_float_primitive() throws Exception {
+        Assert.assertEquals(Float.MAX_VALUE,
+            Primitive.castNumberStrictJava(Float.TYPE, (double)Float.MAX_VALUE));
+    }
+
+    /**
+     * Cast strict double to double primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_double_primitive() throws Exception {
+        Assert.assertEquals(Double.MAX_VALUE,
+            Primitive.castNumberStrictJava(Double.TYPE, Double.MAX_VALUE));
+    }
+
+    /**
+     * Cast number double to long
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_long_number() throws Exception {
+        Assert.assertEquals(0L, Primitive.castNumber(Long.class, (double)0.0));
+    }
+
+    /**
+     * Cast number double to long primitive
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void cast_strict_long_number_primitive() throws Exception {
+        Assert.assertEquals(0L, Primitive.castNumber(Long.TYPE, (double)0.00));
+    }
+
+    /**
+     * Test primitive null type is null
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void get_type_primitive_null() throws Exception {
+        Assert.assertNull(Primitive.NULL.getType());
+    }
+
+    /**
+     * Test primitive unwrap null is null
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void unwrap_primitive_null() throws Exception {
+        Assert.assertNull(Primitive.unwrap((Object[])null));
+    }
+
+    /**
+     * Test primitive unwrap void is exception
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void unwrap_primitive_void() throws Exception {
+        Throwable e = Assert.assertThrows(InterpreterError.class,
+            () -> Assert.assertNull(Primitive.VOID.getValue()));
+        Assert.assertTrue(e.getMessage().contains("attempt to unwrap void type"));
+    }
+
+    /**
+     * Test primitive is not a number exception
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void number_value_primitive_void() throws Exception {
+        Throwable e = Assert.assertThrows(InterpreterError.class,
+            () -> Assert.assertNull(Primitive.VOID.numberValue()));
+        Assert.assertTrue(e.getMessage().contains("Primitive not a number"));
+    }
+
+    /**
+     * Test primitive unwrap null is null
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void unwrap_primitive_null_big_decimal() throws Exception {
+        Throwable e = Assert.assertThrows(InterpreterError.class,
+            () -> Assert.assertNull(new Primitive((BigDecimal)null).getValue()));
+        Assert.assertTrue(e.getMessage().contains("Use Primitve.NULL instead of Primitive(null)"));
+    }
+
+    /**
+     * Test if primitive to wrapper type is assignable
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void is_asssignable_primitive_to_wrapper_type() throws Exception {
         Assert.assertTrue(Types.isBshAssignable(Integer.class, Integer.TYPE));
     }
 
     /**
-     * Test cast primitive to wrapper type
+     * Test cast wide integer to long type
      * @throws Exception in case of failure
      */
     @Test
@@ -53,11 +399,11 @@ public class TypesTest {
     }
 
     /**
-     * Test can cast primitive to wrapper type
+     * Test can cast wrapper type to wide integer
      * @throws Exception in case of failure
      */
     @Test
-    public void can_cast_object_primitive_big_integer_to_long_type() throws Exception {
+    public void can_cast_object_long_integer_to_long_type() throws Exception {
         Assert.assertTrue(Types.isBshAssignable(Long.class, BigInteger.class));
     }
 
@@ -73,11 +419,11 @@ public class TypesTest {
     }
 
     /**
-     * Test can cast primitive to object
+     * Test can casted primitive to object is assignable
      * @throws Exception in case of failure
      */
     @Test
-    public void can_cast_object_primitive_to_object() throws Exception {
+    public void is_assignable_object_primitive_to_object() throws Exception {
         Assert.assertTrue(Types.isBshAssignable(Object.class, Integer.TYPE));
     }
 

--- a/src/test/resources/test-scripts/arraydims.bsh
+++ b/src/test/resources/test-scripts/arraydims.bsh
@@ -3,6 +3,18 @@
 source("TestHarness.bsh");
 source("Assert.bsh");
 
+// Test on identifier defined arraydims on formal parameters #663
+main(String args[]) {
+    assertArrayEquals({"foo", "bar", "baz"}, args);
+}
+main({"foo", "bar", "baz"});
+pars(int a[], int b[][], int c[][][]) {
+    assertArrayEquals({0, 0, 0}, a);
+    assertArrayEquals({{0, 0}, {0, 0}}, b);
+    assertArrayEquals({{{0}}}, c);
+}
+pars(new int[3], new int[2][2], new int[1][1][1]);
+
 oa = new Object [] { "foo", "bar" };
 assert( oa.length == 2 && oa[0] instanceof String );
 

--- a/src/test/resources/test-scripts/class.bsh
+++ b/src/test/resources/test-scripts/class.bsh
@@ -25,9 +25,8 @@ class Foo
     void method()
     {
         assert( a == 5 );
-        assert( a.getClass() == bsh.Primitive.class );
-//        print( a.getClass() );
-        assert( b.getClass() == bsh.Primitive.class );
+        assert( a.getClass().isPrimitive() );
+        assert( b.getType().isPrimitive() );
         new byte[a];
         assert( q == 5 );
         assert( this == instanceThis );
@@ -82,7 +81,7 @@ assert(Foo.a == 5);
 assert(isEvalError("print(Foo.b)"));
 Foo.smethod();
 assert(isEvalError("Foo.method()"));
-assert( Foo.a.getClass() == bsh.Primitive.class );
+assert( Foo.a.getType().isPrimitive() );
 
 // instance
 foo = new Foo();

--- a/src/test/resources/test-scripts/comments.bsh
+++ b/src/test/resources/test-scripts/comments.bsh
@@ -18,3 +18,17 @@ complete();
 
 // to trigger in this file
 // Use a binary editor to remove the trailing linefeed and see this -->
+
+// As per #322
+if (1 == 2)
+    assert(false);
+/***
+This code is commented
+***/
+else if (2 == 2)
+    assert(true);
+/*******
+This is more comments
+*******/
+else
+    assert(false);

--- a/src/test/resources/test-scripts/exceptions5.bsh
+++ b/src/test/resources/test-scripts/exceptions5.bsh
@@ -4,14 +4,20 @@ source("TestHarness.bsh");
 import bsh.ParseException;
 
 // Check that ParseException info is filled out, issue #395
-try { 
+try {
   // Deliberate syntax error
   eval("Number num = (Number a;");
-} catch ( ParseException pe ) { 
+} catch ( ParseException pe ) {
   flag();
   assert( pe.getErrorLineNumber() == 1 );
 }
 
 assert( flag() == 1 );
+
+// Test NPE exception fix on TargetError with null cause. #498
+import bsh.TargetError;
+
+te = new TargetError(null, null, null);
+assert(te.getMessage().contains("Cause is null"));
 
 complete();

--- a/src/test/resources/test-scripts/externalNameSpace.bsh
+++ b/src/test/resources/test-scripts/externalNameSpace.bsh
@@ -20,7 +20,7 @@ assertEquals( 42, myMap.get("foo") );
 
 // primitives get mapped back to prims inside the interpreter
 interpreter.eval("int fooint=42");
-assertSame( bsh.Primitive.class, interpreter.eval("fooint.getClass()") );
+assertTrue( interpreter.eval("fooint.getType().isPrimitive()") );
 assertThat( myMap.get("fooint"), instanceOf(Integer.class) );
 
 interpreter.eval("Integer fooInt=42");
@@ -41,12 +41,12 @@ assertFalse( myMap.get("flag").booleanValue() );
 
 interpreter.eval("int bar = 43");
 // it's a primitive to bsh
-assertTrue( interpreter.eval("bar.getClass() == bsh.Primitive.class") );
+assertTrue( interpreter.eval("bar.getType().isPrimitive()") );
 // it's an Integer to the map
 assertThat( myMap.get("bar"), instanceOf(Integer.class) );
 assertEquals( 43, myMap.get("bar") );
 // check again
-assertTrue( interpreter.eval("bar.getClass() == bsh.Primitive.class") );
+assertTrue( interpreter.eval("bar.getType().isPrimitive()") );
 
 assertNull( interpreter.get("e1") );
 

--- a/src/test/resources/test-scripts/mathmagic.bsh
+++ b/src/test/resources/test-scripts/mathmagic.bsh
@@ -1,0 +1,71 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+o = 5o;
+o = o.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", o, equalTo(1o));
+assertThat("The math equation sum should remain a byte", o, instanceOf(Byte.TYPE));
+s = 5s;
+s = s.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", s, equalTo(1s));
+assertThat("The math equation sum should remain a short", s, instanceOf(Short.TYPE));
+c = 'e';
+c = c.add(2).subtract(6).pow(1).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", c, equalTo('a'));
+assertThat("The math equation sum should remain an int", c, instanceOf(Character.TYPE));
+i = 5i;
+i = i.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", i, equalTo(1));
+assertThat("The math equation sum should remain a char", i, instanceOf(Integer.TYPE));
+l = 5l;
+l = l.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", l, equalTo(1l));
+assertThat("The math equation sum should remain a long", l, instanceOf(Long.TYPE));
+iw = 5w;
+iw = iw.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", iw, equalTo(1w));
+assertThat("The math equation sum should remain a wide int", iw, instanceOf(BigInteger.class));
+f = 5f;
+f = f.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", f, equalTo(1.0f));
+assertThat("The math equation sum should remain a float", f, instanceOf(Float.TYPE));
+d = 5d;
+d = d.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", d, equalTo(1.0));
+assertThat("The math equation sum should remain a long", d, instanceOf(Double.TYPE));
+dw = 5.00w;
+dw = dw.add(2).subtract(6).pow(2).divide(1).multiply(1);
+assertThat("The mathematical chaining sum should total 1", dw, equalTo(1.0000w));
+assertThat("The math equation sum should remain a wide decimal", dw, instanceOf(BigDecimal.class));
+
+
+assertTrue("Test if bit 0 for value 1 is hi for byte", o.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for short", s.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for char", c.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for int", i.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for long", l.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for wide int", iw.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for float", f.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for double", d.testBit(0));
+assertTrue("Test if bit 0 for value 1 is hi for wide decimal", dw.testBit(0));
+
+assertEquals("Test move decimal point to the right by 1 byte", 10o,  o.movePointRight(1));
+assertEquals("Test move decimal point to the right by 1 short", 10s,  s.movePointRight(1));
+assertEquals("Test move decimal point to the right by 1 char", 'ϊ',  c.movePointRight(1));
+assertEquals("Test move decimal point to the right by 1 int", 10,  i.movePointRight(1));
+assertEquals("Test move decimal point to the right by 1 long", 10l,  l.movePointRight(1));
+assertEquals("Test move decimal point to the right by 1 wide int", 10w,  iw.movePointRight(1));
+assertEquals("Test move decimal point to the right by 1 float", 10.0f,  f.movePointRight(1), 1);
+assertEquals("Test move decimal point to the right by 1 double", 10.0d,  d.movePointRight(1), 1);
+assertEquals("Test move decimal point to the right by 1 wide decimal", 10.000w,  dw.movePointRight(1));
+
+assertEquals("Test return string method", "1.0", i.toPlainString());
+assertEquals("Test return string method", "1.0", f.toEngineeringString());
+
+assert(isEvalError("Method nonExist() not found", "iw.nonExist()"));
+assert(isEvalError("Method nonExist() not found", "dw.nonExist()"));
+
+complete();
+

--- a/src/test/resources/test-scripts/methods3.bsh
+++ b/src/test/resources/test-scripts/methods3.bsh
@@ -20,4 +20,9 @@ URL foo11() { }
 URL [] foo12() { }
 URL [][] foo13() { }
 
+assert(isEvalError("Insufficient parameters passed for method", "10.0w.max();"));
+assert(isEvalError("Rounding necessary", "10.4353536365345f.setScale(1);"));
+assert(isEvalError("not found in class'float'", "10.4353536365345f.setScale(true);"));
+assert(isEvalError("Method found on BigDecimal", "10.435f.compareTo(null);"));
+
 complete();

--- a/src/test/resources/test-scripts/null_binary_expressions.bsh
+++ b/src/test/resources/test-scripts/null_binary_expressions.bsh
@@ -178,7 +178,7 @@ assert(isEvalError('bad operand types for binary operator "@or"', '1 @or o'));
 assert(isEvalError('bad operand types for binary operator "&&"', '1 && o'));
 assert(isEvalError('bad operand types for binary operator "@and"', '1 @and o'));
 
-// null Integer wrapper class, represents all Number types 
+// null Integer wrapper class, represents all Number types
 Integer i = null;
 assert(isEvalError('incomparable types: String and Integer', 's == i'));
 assertEquals("null1", i + "1");
@@ -417,7 +417,8 @@ assertTrue(b == Boolean.valueOf(true));
 assertTrue(b == Boolean.TRUE);
 assertFalse(null == b);
 assertFalse(b == null);
-assertTrue(b == new Boolean(true));
+assertFalse(b == new Boolean(true)); // now works like JAVA does, false not the same instance (deprecated)
+assertTrue(b.booleanValue() == true.booleanValue());
 assertFalse(b != b);
 b = null;
 assert(isEvalError('bad operand types for binary operator "+"', 'b + true'));

--- a/src/test/resources/test-scripts/operators.bsh
+++ b/src/test/resources/test-scripts/operators.bsh
@@ -3,10 +3,6 @@
 source("TestHarness.bsh");
 source("Assert.bsh");
 
-/**
-    I'm just taking a shotgun approach here... we need better tests.
-*/
-
 a=5;
 a*=2;
 assert(a==10);
@@ -55,8 +51,146 @@ assertEquals("( true ? false : ( false ? true : false ))", ( true ? false : ( fa
 assertEquals("( true && false ? true : ( true && false ? true : false ))", ( true && false ? true : ( true && false ? true : false )), false);
 assertEquals("(( true && false ) ? true : (( true && false ) ? false : true ))", (( true && false ) ? true : (( true && false ) ? false : true )), true);
 
+//Space Ship operator
+// a < b == -1
+assertEquals(-1, 0 <=> 1);
+assertEquals(-1, 0o <=> 1o);
+assertEquals(-1, 0s <=> 1s);
+assertEquals(-1, 0i <=> 1i);
+assertEquals(-1, 0l <=> 1l);
+assertEquals(-1, 0w <=> 1w);
+assertEquals(-1, "0" <=> "1");
+assertEquals(-1, null<=> "0");
+assertEquals(-1, null <=> "1");
+assertEquals(-1, 0.0 <=> 1.0);
+assertEquals(-1, 0.0f <=> 1.0f);
+assertEquals(-1, 0.0d <=> 1.0d);
+assertEquals(-1, 0.0w <=> 1.0w);
+assertEquals(-1, null <=> 0l);
+assertEquals(-1, null <=> 0.0f);
+// a == b == 0
+assertEquals(0, 1 <=> 1);
+assertEquals(0, 1o <=> 1o);
+assertEquals(0, 1s <=> 1s);
+assertEquals(0, 1i <=> 1i);
+assertEquals(0, 1l <=> 1l);
+assertEquals(0, 1w <=> 1w);
+assertEquals(0, "1" <=> "1");
+assertEquals(0, 1.0 <=> 1.0);
+assertEquals(0, 1.0f <=> 1.0f);
+assertEquals(0, 1.0d <=> 1.0d);
+assertEquals(0, 1.0w <=> 1.0w);
+assertEquals(0, null <=> null);
+assertEquals(0, null <=> null);
+// a > b == 1
+assertEquals(1, 2 <=> 1);
+assertEquals(1, 2o <=> 1o);
+assertEquals(1, 2s <=> 1s);
+assertEquals(1, 2i <=> 1i);
+assertEquals(1, 2l <=> 1l);
+assertEquals(1, 2w <=> 1w);
+assertEquals(1, "2" <=> "1");
+assertEquals(1, "2" <=> null);
+assertEquals(1, "1" <=> null);
+assertEquals(1, 2.0 <=> 1.0);
+assertEquals(1, 2.0f <=> 1.0f);
+assertEquals(1, 2.0d <=> 1.0d);
+assertEquals(1, 2.0w <=> 1.0w);
+assertEquals(1, 0l <=> null);
+assertEquals(1, 0.0f <=> null);
+// non comparible
+Object a = "a";
+var b = "b";
+assertEquals(-1, a <=> b);
+assertEquals(-1, null <=> a);
+assertEquals(-1, null <=> b);
+assertEquals(1, b <=> a);
+assertEquals(1, a <=> null);
+assertEquals(1, b <=> null);
+assertEquals(0, a <=> a);
+assertEquals(0, b <=> b);
+
+// Elvis Operator
+// returns true on true
+assertTrue(true ?: false);
+assertTrue(true ?: true);
+assertTrue(true ?: 1o);
+assertTrue(true ?: 1s);
+assertTrue(true ?: 1i);
+assertTrue(true ?: 1l);
+assertTrue(true ?: 1w);
+assertTrue(true ?: 1.0f);
+assertTrue(true ?: 1.0d);
+assertTrue(true ?: 1.0w);
+assertTrue(true ?: "1");
+assertTrue(true ?: a);
+// returns value on false
+assertFalse(false ?: false);
+assertTrue(false ?: true);
+assertEquals(1o, false ?: 1o);
+assertEquals(1s, false ?: 1s);
+assertEquals(1i, false ?: 1i);
+assertEquals(1l, false ?: 1l);
+assertEquals(1w, false ?: 1w);
+assertEquals(1.0f, false ?: 1.0f, 1);
+assertEquals(1.0d, false ?: 1.0d, 1);
+assertEquals(1.0w, false ?: 1.0w);
+assertEquals("1", false ?: "1");
+assertEquals(a, false ?: a);
+
+// Null Coalesce Operator
+assertEquals(9, 9 ?? 8 ?? 7 ?? 6 ?? 5 ?? 4 ?? 3 ?? 2 ?? 1);
+assertEquals(8, null ?? 8 ?? 7 ?? 6 ?? 5 ?? 4 ?? 3 ?? 2 ?? 1);
+assertEquals(7, null ?? null ?? 7 ?? 6 ?? 5 ?? 4 ?? 3 ?? 2 ?? 1);
+assertEquals(6, null ?? null ?? null ?? 6 ?? 5 ?? 4 ?? 3 ?? 2 ?? 1);
+assertEquals(5, null ?? null ?? null ?? null ?? 5 ?? 4 ?? 3 ?? 2 ?? 1);
+assertEquals(4, null ?? null ?? null ?? null ?? null ?? 4 ?? 3 ?? 2 ?? 1);
+assertEquals(3, null ?? null ?? null ?? null ?? null ?? null ?? 3 ?? 2 ?? 1);
+assertEquals(2, null ?? null ?? null ?? null ?? null ?? null ?? null ?? 2 ?? 1);
+assertEquals(1, null ?? null ?? null ?? null ?? null ?? null ?? null ?? null ?? 1);
+assertEquals("1", null ?? null ?? null ?? null ?? null ?? null ?? null ?? null ?? "1");
+assertEquals(a, null ?? null ?? null ?? null ?? null ?? null ?? null ?? null ?? a);
+assertNull(null ?? null ?? null ?? null ?? null ?? null ?? null ?? null ?? null);
+
+// Null Coalesce Assign Operator
+a = null;
+assertNull(a);
+a ??= 1;
+assertEquals(1, a);
+a ??= 2;
+assertEquals(1, a);
+a = null;
+a ??= null ?? 2;
+assertEquals(2, a);
+
+// Safe Navigate Operator
+class R {
+    int v;
+    g(r, v) {
+        if (null != r)
+            r.v = v;
+        return r;
+    }
+}
+r = new R();
+assertEquals(1, r?.g(r, 1)?.v);
+assertEquals(2, r?.g(r, 1)?.g(r, 2)?.v);
+assertEquals(3, r?.g(r, 1)?.g(r, 2)?.g(r, 3)?.v);
+assertEquals(4, r?.g(r, 1)?.g(r, 2)?.g(r, 3)?.g(r, 4)?.v);
+assertNull(r?.g(r, 1)?.g(r, 2)?.g(r, 3)?.g(null, 4)?.v);
+assertEquals(3, r.v);
+assertNull(r?.g(r, 1)?.g(r, 2)?.g(null, 3)?.g(r, 4)?.v);
+assertEquals(2, r.v);
+assertNull(r?.g(r, 1)?.g(null, 2)?.g(r, 3)?.g(r, 4)?.v);
+assertEquals(1, r.v);
+r.v = 0;
+assertNull(r?.g(null, 1)?.g(r, 2)?.g(r, 3)?.g(r, 4)?.v);
+assertEquals(0, r.v);
+
+
 /*
     Uncomment these if we start enforcing operations on primitive/non-prim
+    Added: Are we sure we want to inforce these? BeanShell doesn't break like JAVA does.
 */
 
 /*

--- a/src/test/resources/test-scripts/primitives2.bsh
+++ b/src/test/resources/test-scripts/primitives2.bsh
@@ -5,26 +5,26 @@ source("Assert.bsh");
 
 check(s, a, val, java.lang.Class cl) {
     // we're looking at the Primitive here
-    assertEquals( s, cl, a.getValue().getClass() );
-    assertTrue( s, a.getValue() == val );
+    assertEquals( s, cl, a.getClass() );
+    assertTrue( s, a == val );
 }
 
 // Promotion tests
 // Should be integer
-check("check 5 5 Integer", 5, 5, Integer.class);
-check("check 5+5 10 Integer", 5+5, 10, Integer.class);
-check("check 5/2 2 Integer", 5/2, 2, Integer.class);
+check("check 5 5 Integer", 5, 5, Integer.TYPE);
+check("check 5+5 10 Integer", 5+5, 10, Integer.TYPE);
+check("check 5/2 2 Integer", 5/2, 2, Integer.TYPE);
 
 // Should be double
-check("check 4.0 4.0 Long", 4.0, 4.0, Double.class);
-check("check 5.0+5.0 10.0 Long", 5.0+5.0, 10.0, Double.class);
-check("check 1+1.0 2.0 Long", 1+1.0, 2.0, Double.class);
+check("check 4.0 4.0 Double", 4.0, 4.0, Double.TYPE);
+check("check 5.0+5.0 10.0 Double", 5.0+5.0, 10.0, Double.TYPE);
+check("check 1+1.0 2.0 Double", 1+1.0, 2.0, Double.TYPE);
 
-check("check (byte)5 5 Byte", (byte)5, 5, Byte.class);
-check("check (short)5 5 Short", (short)5, 5, Short.class);
-check("check (long)5 5 Long", (long)5, 5, Long.class);
-check("check '5' '5' Character", '5', '5', Character.class);
-check("check (float)5.0 5.0 Float", (float)5.0, 5.0, Float.class );
+check("check (byte)5 5 Byte", (byte)5, 5, Byte.TYPE);
+check("check (short)5 5 Short", (short)5, 5, Short.TYPE);
+check("check (long)5 5 Long", (long)5, 5, Long.TYPE);
+check("check '5' '5' Character", '5', '5', Character.TYPE);
+check("check (float)5.0 5.0 Float", (float)5.0, 5.0, Float.TYPE );
 
 assertThat(3.4028235E38, instanceOf(Double.TYPE));
 assertThat(3.4028236E38, instanceOf(Double.TYPE));
@@ -42,5 +42,10 @@ Byte [] bwa = { 1, 2 };
 byte [] ba1 = { new Byte((byte)1), new Byte((byte)2) };
 byte [] ba2 = { 1, 2 };
 byte [] ba2 = { 1L, 2L };
+
+var c = 1;
+assertEquals(c.getType(), Integer.TYPE);
+assertEquals(c.getClass(), Integer.TYPE);
+assertThat(c, instanceOf(Integer.TYPE));
 
 complete();

--- a/src/test/resources/test-scripts/primitives_assignment.bsh
+++ b/src/test/resources/test-scripts/primitives_assignment.bsh
@@ -1,4 +1,5 @@
 #!/bin/java bsh.Interpreter
+import bsh.Types;
 
 source("TestHarness.bsh");
 source("Assert.bsh");
@@ -13,6 +14,7 @@ float fdelta = 0.000001f;
 short s = 2;
 byte b = 2;
 char c = 2;
+Number n = 2;
 
 assertEquals(2, a);
 assertEquals(2.0, d, ddelta);
@@ -24,32 +26,38 @@ assertTrue(a > 1);
 assertTrue(d > 1.0);
 assertTrue(f > 1.0);
 assertTrue(l > 1L);
+assertTrue(n > 1);
 assertFalse(a > 3);
 assertFalse(d > 3.0);
 assertFalse(f > 3.0);
 assertFalse(l > 3L);
+assertFalse(n > 3);
 
 // GTX: "@gt"
 assertTrue(a @gt 1);
 assertTrue(d @gt 1.0);
 assertTrue(f @gt 1.0);
 assertTrue(l @gt 1L);
+assertTrue(n @gt 1);
 
 // LT: "<"
 assertTrue(a < 3);
 assertTrue(d < 3.0);
 assertTrue(f < 3.0);
 assertTrue(l < 3L);
+assertTrue(n < 3);
 assertFalse(a < 1);
 assertFalse(d < 1.0);
 assertFalse(f < 1.0);
 assertFalse(l < 1L);
+assertFalse(n < 1);
 
 // LTX: "@lt"
 assertTrue(a @lt 3);
 assertTrue(d @lt 3.0);
 assertTrue(f @lt 3.0);
 assertTrue(l @lt 3L);
+assertTrue(n @lt 3);
 
 // BANG: "!"
 assertTrue( ! false );
@@ -73,10 +81,12 @@ assertTrue(a == 2);
 assertTrue(d == 2.0);
 assertTrue(f == 2.0);
 assertTrue(l == 2L);
+assertTrue(n == 2);
 assertFalse(a == 1);
 assertFalse(d == 1.0);
 assertFalse(f == 1.0);
 assertFalse(l == 1L);
+assertFalse(n == 1);
 assertTrue(Character.valueOf('*') == '*');
 assertTrue(Character.valueOf('*') == 42);
 assertTrue(Long.valueOf(1L) == Long.valueOf(1L));
@@ -115,32 +125,38 @@ assertTrue(a <= 2);
 assertTrue(d <= 2.0);
 assertTrue(f <= 2.0);
 assertTrue(l <= 2L);
+assertTrue(n <= 2);
 assertFalse(a <= 1);
 assertFalse(d <= 1.0);
 assertFalse(f <= 1.0);
 assertFalse(l <= 1L);
+assertFalse(n <= 1);
 
 // LEX: "@lteq"
 assertTrue(a @lteq 2);
 assertTrue(d @lteq 2.0);
 assertTrue(f @lteq 2.0);
 assertTrue(l @lteq 2L);
+assertTrue(n @lteq 2);
 
 // GE: ">="
 assertTrue(a >= 2);
 assertTrue(d >= 2.0);
 assertTrue(f >= 2.0);
 assertTrue(l >= 2L);
+assertTrue(n >= 2);
 assertFalse(a >= 3);
 assertFalse(d >= 3.0);
 assertFalse(f >= 3.0);
 assertFalse(l >= 3L);
+assertFalse(n >= 3);
 
 // GEX: "@gteq"
 assertTrue(a @gteq 2);
 assertTrue(d @gteq 2.0);
 assertTrue(f @gteq 2.0);
 assertTrue(l @gteq 2L);
+assertTrue(n @gteq 2);
 
 // NE: "!="
 obj = new Object();
@@ -150,11 +166,13 @@ assertTrue(a != 1);
 assertTrue(d != 1.0);
 assertTrue(f != 1.0);
 assertTrue(l != 1L);
+assertTrue(n != 1);
 assertTrue(true != false);
 assertFalse(a != 2);
 assertFalse(d != 2.0);
 assertFalse(f != 2.0);
 assertFalse(l != 2L);
+assertFalse(n != 2);
 assertFalse(true != true);
 
 // BOOL_OR: "||"
@@ -202,6 +220,9 @@ assertEquals(4.0, f, fdelta);
 assertEquals(3L, ++l);
 assertEquals(3L, l++);
 assertEquals(4L, l);
+assertEquals(3, ++n);
+assertEquals(3, n++);
+assertEquals(4, n);
 assertEquals(3, ++b);
 assertEquals(3, ++s);
 assertEquals(3, ++c);
@@ -219,6 +240,9 @@ assertEquals(2.0, f, fdelta);
 assertEquals(3L, --l);
 assertEquals(3L, l--);
 assertEquals(2L, l);
+assertEquals(3, --n);
+assertEquals(3, n--);
+assertEquals(2, n);
 assertEquals(2, --b);
 assertEquals(2, --s);
 assertEquals(2, --c);
@@ -228,10 +252,12 @@ assertEquals(3, a + 1);
 assertEquals(3.0, d + 1.0, ddelta);
 assertEquals(3.0, f + 1.0, fdelta);
 assertEquals(3L, l + 1L);
+assertEquals(3, n + 1);
 assertEquals(2, +a);
 assertEquals(2.0, +d, ddelta);
 assertEquals(2.0, +f, fdelta);
 assertEquals(2L, +l);
+assertEquals(2, +n);
 assertEquals(195, 'a' + 'b');
 
 // MINUS: "-"
@@ -239,6 +265,7 @@ assertEquals(1, a - 1);
 assertEquals(1.0, d - 1.0, ddelta);
 assertEquals(1.0, f - 1.0, fdelta);
 assertEquals(1L, l - 1L);
+assertEquals(1, n - 1);
 assertEquals(-3L, -2L - 1L);
 assertEquals(2L, 3L - 1L);
 assertEquals(-4L, -3L - 1L);
@@ -246,24 +273,28 @@ assertEquals(-2, -a);
 assertEquals(-2.0, -d, ddelta);
 assertEquals(-2.0, -f, fdelta);
 assertEquals(-2L, -l);
+assertEquals(-2, -n);
 
 // STAR: "*"
 assertEquals(2, a * 1);
 assertEquals(2.0, d * 1.0, ddelta);
 assertEquals(2.0, f * 1.0, fdelta);
 assertEquals(2L, l * 1L);
+assertEquals(2, n * 1);
 
 // SLASH: "/"
 assertEquals(2, a / 1);
 assertEquals(2.0, d / 1.0, ddelta);
 assertEquals(2.0, f / 1.0, fdelta);
 assertEquals(2L, l / 1L);
+assertEquals(2, n / 1);
 
 // BIT_AND: "&"
 assertEquals(2, a & 2);
 assertEquals(0, a & 1);
 assertEquals(2L, l & 2L);
 assertEquals(0L, l & 1L);
+assertEquals(0, n & 1);
 assertTrue(true & true);
 
 // BIT_ANDX: "@bitwise_and"
@@ -271,6 +302,8 @@ assertEquals(2, a @bitwise_and 2);
 assertEquals(0, a @bitwise_and 1);
 assertEquals(2L, l @bitwise_and 2L);
 assertEquals(0L, l @bitwise_and 1L);
+assertEquals(2, n @bitwise_and 2);
+assertEquals(0, n @bitwise_and 1);
 assertTrue(true @bitwise_and true);
 
 // BIT_OR: "|"
@@ -278,6 +311,8 @@ assertEquals(2, a | 2);
 assertEquals(3, a | 1);
 assertEquals(2L, l | 2L);
 assertEquals(3L, l | 1L);
+assertEquals(2, n | 2);
+assertEquals(3, n | 1);
 assertTrue(true | false);
 
 // BIT_ORX: "@bitwise_or"
@@ -285,6 +320,8 @@ assertEquals(2, a @bitwise_or 2);
 assertEquals(3, a @bitwise_or 1);
 assertEquals(2L, l @bitwise_or 2L);
 assertEquals(3L, l @bitwise_or 1L);
+assertEquals(2, n @bitwise_or 2);
+assertEquals(3, n @bitwise_or 1);
 assertTrue(true @bitwise_or false);
 
 // XOR: "^"
@@ -292,6 +329,8 @@ assertEquals(0, a ^ 2);
 assertEquals(3, a ^ 1);
 assertEquals(0L, l ^ 2L);
 assertEquals(3L, l ^ 1L);
+assertEquals(0, n ^ 2);
+assertEquals(3, n ^ 1);
 assertTrue(true ^ false);
 
 // XORX: "@bitwise_xor"
@@ -299,6 +338,8 @@ assertEquals(0, a @bitwise_xor 2);
 assertEquals(3, a @bitwise_xor 1);
 assertEquals(0L, l @bitwise_xor 2L);
 assertEquals(3L, l @bitwise_xor 1L);
+assertEquals(0, n @bitwise_xor 2);
+assertEquals(3, n @bitwise_xor 1);
 assertTrue(true @bitwise_xor false);
 
 // MOD: "%"
@@ -310,6 +351,8 @@ assertEquals(0.0, 2.0 % f, fdelta);
 assertEquals(1.0, 3.0 % f, fdelta);
 assertEquals(0L, 2L % l);
 assertEquals(1L, 3L % l);
+assertEquals(0, 2 % n);
+assertEquals(1, 3 % n);
 
 // MODX: "@mod"
 assertEquals(0, 2 @mod a);
@@ -320,6 +363,8 @@ assertEquals(0.0, 2.0 @mod f, fdelta);
 assertEquals(1.0, 3.0 @mod f, fdelta);
 assertEquals(0L, 2L @mod l);
 assertEquals(1L, 3L @mod l);
+assertEquals(0, 2 @mod n);
+assertEquals(1, 3 @mod n);
 
 // POWER: "**"
 assertEquals(4, a ** 2);
@@ -343,36 +388,48 @@ assertEquals(8, a << 2);
 assertEquals(4, a << 1);
 assertEquals(8L, l << 2L);
 assertEquals(4L, l << 1L);
+assertEquals(8, n << 2);
+assertEquals(4, n << 1);
 
 // LSHIFTX: "@left_shift"
 assertEquals(8, a @left_shift 2);
 assertEquals(4, a @left_shift 1);
 assertEquals(8L, l @left_shift 2L);
 assertEquals(4L, l @left_shift 1L);
+assertEquals(8, n @left_shift 2);
+assertEquals(4, n @left_shift 1);
 
 // RSIGNEDSHIFT: ">>"
 assertEquals(0, a >> 2);
 assertEquals(1, a >> 1);
 assertEquals(0L, l >> 2L);
 assertEquals(1L, l >> 1L);
+assertEquals(0, n >> 2);
+assertEquals(1, n >> 1);
 
 // RSIGNEDSHIFTX: "@right_shift"
 assertEquals(0, a @right_shift 2);
 assertEquals(1, a @right_shift 1);
 assertEquals(0L, l @right_shift 2L);
 assertEquals(1L, l @right_shift 1L);
+assertEquals(0, n @right_shift 2);
+assertEquals(1, n @right_shift 1);
 
 // RUNSIGNEDSHIFT: ">>>" >
 assertEquals(0, a >>> 2);
 assertEquals(1, a >>> 1);
 assertEquals(0L, l >>> 2L);
 assertEquals(1L, l >>> 1L);
+assertEquals(0, n >>> 2);
+assertEquals(1, n >>> 1);
 
 // RUNSIGNEDSHIFTX: "@right_unsigned_shift" >
 assertEquals(0, a @right_unsigned_shift 2);
 assertEquals(1, a @right_unsigned_shift 1);
 assertEquals(0L, l @right_unsigned_shift 2L);
 assertEquals(1L, l @right_unsigned_shift 1L);
+assertEquals(0, n @right_unsigned_shift 2);
+assertEquals(1, n @right_unsigned_shift 1);
 
 // PLUSASSIGN: "+="
 assertEquals(3, a += 1);
@@ -383,6 +440,8 @@ assertEquals(3.0, f += 1.0, fdelta);
 assertEquals(3.0, f, fdelta);
 assertEquals(3L, l += 1L);
 assertEquals(3L, l);
+assertEquals(3, n += 1);
+assertEquals(3, n);
 Double dd = 2.0;
 assertEquals(4.0, dd += dd, ddelta);
 assertEquals(6.0, dd += 2.0, ddelta);
@@ -414,6 +473,8 @@ assertEquals(2.0, f -= 1.0, fdelta);
 assertEquals(2.0, f, fdelta);
 assertEquals(2L, l -= 1L);
 assertEquals(2L, l);
+assertEquals(2, n -= 1);
+assertEquals(2, n);
 
 // STARASSIGN: "*="
 assertEquals(4, a *= 2);
@@ -424,6 +485,8 @@ assertEquals(4.0, f *= 2.0, fdelta);
 assertEquals(4.0, f, fdelta);
 assertEquals(4L, l *= 2L);
 assertEquals(4L, l);
+assertEquals(4, n *= 2);
+assertEquals(4, n);
 
 // SLASHASSIGN: "/="
 assertEquals(2, a /= 2);
@@ -434,30 +497,40 @@ assertEquals(2.0, f /= 2.0, fdelta);
 assertEquals(2.0, f, fdelta);
 assertEquals(2L, l /= 2L);
 assertEquals(2L, l);
+assertEquals(2, n /= 2);
+assertEquals(2, n);
 
 // ANDASSIGN: "&="
 assertEquals(2, a &= 2);
 assertEquals(2, a);
 assertEquals(2L, l &= 2L);
 assertEquals(2L, l);
+assertEquals(2, n &= 2);
+assertEquals(2, n);
 
 // ANDASSIGNX: "@and_assign"
 assertEquals(2, a @and_assign 2);
 assertEquals(2, a);
 assertEquals(2L, l @and_assign 2L);
 assertEquals(2L, l);
+assertEquals(2, n @and_assign 2);
+assertEquals(2, n);
 
 // ORASSIGN: "|=" >
 assertEquals(2, a |= 2);
 assertEquals(2, a);
 assertEquals(2L, l |= 2L);
 assertEquals(2L, l);
+assertEquals(2, n |= 2);
+assertEquals(2, n);
 
 // ORASSIGNX: "@or_assign"
 assertEquals(2, a @or_assign 2);
 assertEquals(2, a);
 assertEquals(2L, l @or_assign 2L);
 assertEquals(2L, l);
+assertEquals(2, n @or_assign 2);
+assertEquals(2, n);
 
 // XORASSIGN: "^="
 assertEquals(3, a ^= 1);
@@ -466,6 +539,9 @@ assertEquals(2, a);
 assertEquals(3L, l ^= 1L);
 assertEquals(2L, l ^= 1L);
 assertEquals(2L, l);
+assertEquals(3, n ^= 1);
+assertEquals(2, n ^= 1);
+assertEquals(2, n);
 
 // XORASSIGNX: "@xor_assign"
 assertEquals(3, a @xor_assign 1);
@@ -474,6 +550,9 @@ assertEquals(2, a);
 assertEquals(3L, l @xor_assign 1L);
 assertEquals(2L, l @xor_assign 1L);
 assertEquals(2L, l);
+assertEquals(3, n @xor_assign 1);
+assertEquals(2, n @xor_assign 1);
+assertEquals(2, n);
 
 // MODASSIGN: "%="
 assertEquals(2, a %= 3);
@@ -484,6 +563,8 @@ assertEquals(2.0, f %= 3, fdelta);
 assertEquals(2.0, f, fdelta);
 assertEquals(2L, l %= 3L);
 assertEquals(2L, l);
+assertEquals(2, n %= 3);
+assertEquals(2, n);
 
 //MODASSIGNX: "@mod_assign"
 assertEquals(2, a @mod_assign 3);
@@ -494,53 +575,68 @@ assertEquals(2.0, f @mod_assign 3, fdelta);
 assertEquals(2.0, f, fdelta);
 assertEquals(2L, l @mod_assign 3L);
 assertEquals(2L, l);
+assertEquals(2, n @mod_assign 3);
+assertEquals(2, n);
 
 // LSHIFTASSIGN: "<<="
 assertEquals(8, a <<= 2);
 assertEquals(8, a);
 assertEquals(8L, l <<= 2L);
 assertEquals(8L, l);
+assertEquals(8, n <<= 2);
+assertEquals(8, n);
 
 // LSHIFTASSIGNX: "@left_shift_assign"
 assertEquals(32, a @left_shift_assign 2);
 assertEquals(32, a);
 assertEquals(32L, l @left_shift_assign 2L);
 assertEquals(32L, l);
+assertEquals(32, n @left_shift_assign 2);
+assertEquals(32, n);
 
 // RSIGNEDSHIFTASSIGN: ">>=" >
 assertEquals(8, a >>= 2);
 assertEquals(8, a);
 assertEquals(8L, l >>= 2L);
 assertEquals(8L, l);
+assertEquals(8, n >>= 2);
+assertEquals(8, n);
 
 // RSIGNEDSHIFTASSIGNX: "@right_shift_assign" >
 assertEquals(2, a @right_shift_assign 2);
 assertEquals(2, a);
 assertEquals(2L, l @right_shift_assign 2L);
 assertEquals(2L, l);
+assertEquals(2, n @right_shift_assign 2);
+assertEquals(2, n);
 
 // RUNSIGNEDSHIFTASSIGN: ">>>=" >
 assertEquals(1, a >>>= 1);
 assertEquals(1, a);
 assertEquals(1L, l >>>= 1L);
 assertEquals(1L, l);
+assertEquals(1, n >>>= 1);
+assertEquals(1, n);
 
 // RUNSIGNEDSHIFTASSIGNX: "@right_unsigned_shift_assign"
 assertEquals(0, a @right_unsigned_shift_assign 1);
 assertEquals(0, a);
 assertEquals(0L, l @right_unsigned_shift_assign 1L);
 assertEquals(0L, l);
+assertEquals(0, n @right_unsigned_shift_assign 1);
+assertEquals(0, n);
 
 import bsh.Primitive;
 // missing null is number
-assertTrue(a.isNumber());
-assertFalse(false.isNumber());
+assertTrue(Types.isNumeric(a));
+assertFalse(Types.isNumeric(false));
 assertFalse(void.isNumber());
 
 assertEquals("void", void.toString());
 
-assertEquals(0, a.numberValue());
-assertEquals(2, c.numberValue());
+assertEquals(0, (Number)a);
+assertEquals(2, (Number)c);
+assertEquals(0, n);
 
 assertFalse(Primitive.getDefaultValue(Boolean.TYPE));
 assertNull(Primitive.getDefaultValue(String.class));
@@ -609,10 +705,11 @@ assert(isEvalError("Can't assign to prefix.", "null += a;"));
 assert(isEvalError("illegal use of null object or 'null' literal", "~null;"));
 assert(isEvalError("Cannot cast primitive value to object type java.lang.String", "String sss = true;"));
 assert(isEvalError("Cannot cast String to boolean", "(boolean) 'true';"));
-assert(isEvalError("cannot assign number 4 to type Number", "(Number) 4s;"));
-assert(isEvalError("Primitive not a number", "false.numberValue();"));
-assert(isEvalError("Primitive not a boolean", "a.booleanValue();"));
-assert(isEvalError("Primitive not a number", "false.intValue();"));
+//assert(isEvalError("cannot assign number 4 to type Number", "(Number) 4s;")); // work like java does #684
+assert(isEvalError("numberValue() not found in class'boolean'", "false.numberValue();"));
+assert(isEvalError("booleanValue() not found in class'int'", "a.booleanValue();"));
+assert(isEvalError("intValue() not found in class'boolean'", "false.intValue();"));
+assert(isEvalError("Primitive not a number", "void.numberValue();"));
 assert(isEvalError("attempt to unwrap void type", "void.getValue();"));
 assert(isEvalError("Can't shift floatingpoint values", "d << 2.0;"));
 assert(isEvalError("Can't shift floatingpoint values", "2 << 2E606;"));

--- a/src/test/resources/test-scripts/types.bsh
+++ b/src/test/resources/test-scripts/types.bsh
@@ -1,10 +1,24 @@
 #!/bin/java bsh.Interpreter
+import bsh.Types;
+import bsh.ClassIdentifier;
 
 source("TestHarness.bsh");
+source("Assert.bsh");
 
-assert( java.lang.String instanceof bsh.ClassIdentifier );
+assert( java.lang.String instanceof ClassIdentifier );
 o=java.lang.String;
-assert( o instanceof bsh.ClassIdentifier );
+assert( o instanceof ClassIdentifier );
+
+assertEquals("Class Identifier: java.lang.String", ((ClassIdentifier)o).toString());
+
+// Primitive type resolution
+assertEquals(Boolean.TYPE, Types.getType(true));
+assertEquals(Byte.TYPE, Types.getType(1o));
+assertEquals(Short.TYPE, Types.getType(1s));
+assertEquals(Character.TYPE, Types.getType('a'));
+assertEquals(Integer.TYPE, Types.getType(1i));
+assertEquals(Long.TYPE, Types.getType(1l));
+assertEquals(Float.TYPE, Types.getType(1f));
+assertEquals(Double.TYPE, Types.getType(1d));
 
 complete();
-


### PR DESCRIPTION
Fixes #498 NPE in TargetError with null cause.
Fixes #322 /*** ***/ is not a formal comment
Fixes #536 added 5 new operators ??, ??=, ?:, ?., and <=>
Fixes #609 obfuscate bsh.Primitive to expose math methods
Fixes #684 can now cast to type Number from primitive
Fixes #663 identifier defined array dimensions for parameters
Fixes #651 avoid NPE on package access property and use null
Support for var keyword tested, appears to work with nothing added.
Added Types get primitive type and isNumeric from class
Auto narrowing and widening of primitives cast added
Detect method signature of widening to BigInteger and BigDecimal as assignable and more specific then Object

I am sure there are a few more things to note which I can't remember now off hand