### PR TITLE
Fix interpreter prompt and unset

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Tue Jan 03 23:24:15 SAST 2023
-build=2842
+#Sat Jan 07 05:40:49 SAST 2023
+build=2930
 release=${project.version}

--- a/src/main/resources/bsh/commands/unset.bsh
+++ b/src/main/resources/bsh/commands/unset.bsh
@@ -1,16 +1,13 @@
 /**
     "Undefine" the variable specifed by 'name' (So that it tests == void).
-    <p>
-    <em>Note: there will be a better way to do this in the future.  This is
-    currently equivalent to doing namespace.setVariable(name, null);</em>
 */
 
 bsh.help.unset = "usage: unset( name )";
 
 void unset( String name )
 {
-    if ( arg == null ) // ???
+    if ( name == null )
         return;
 
-    this.caller.namespace.unsetVariable( name );
+    this.interpreter.unset( name );
 }

--- a/src/test/java/bsh/InterpreterTest.java
+++ b/src/test/java/bsh/InterpreterTest.java
@@ -251,6 +251,21 @@ public class InterpreterTest {
     }
 
     @Test
+    public void get_default_output() throws Exception {
+        PrintStream berr = new PrintStream(new ByteArrayOutputStream());
+        PrintStream bout = new PrintStream(new ByteArrayOutputStream());
+
+        Interpreter bsh = new Interpreter(new StringReader(""), bout, berr, false);
+        bsh.setExitOnEOF(false);
+        assertEquals(berr, bsh.getErr());
+        assertEquals(bout, bsh.getOut());
+        bsh.setErr(null);
+        bsh.setOut(null);
+        assertEquals(System.err, bsh.getErr());
+        assertEquals(System.out, bsh.getOut());
+    }
+
+    @Test
     public void set_prompt_by_interpreter() throws Exception {
         final StringReader in = new StringReader("\n");
         for (String P: new String[] { "abc> ", "cde# " }) {
@@ -262,6 +277,34 @@ public class InterpreterTest {
                 bsh.run();
                 assertTrue(baos.toString().contains(P));
             }
+        }
+    }
+
+    @Test
+    public void overwrite_get_prompt_by_interpreter() throws Exception {
+        final StringReader in = new StringReader("\n");
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {
+            Interpreter bsh = new Interpreter(in, new PrintStream(baos),
+                new PrintStream(baos), true);
+
+            bsh.setExitOnEOF(false);
+            bsh.eval("getBshPrompt() { return 'abc>'; }");
+            bsh.run();
+            assertTrue(baos.toString().contains("abc>"));
+        }
+    }
+
+    @Test
+    public void overwrite_get_prompt_exception() throws Exception {
+        final StringReader in = new StringReader("\n");
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {
+            Interpreter bsh = new Interpreter(in, new PrintStream(baos),
+                new PrintStream(baos), true);
+
+            bsh.setExitOnEOF(false);
+            bsh.eval("getBshPrompt() { throw new Exception('prompt exception'); }");
+            bsh.run();
+            assertTrue(baos.toString().contains("bsh %"));
         }
     }
 

--- a/src/test/resources/test-scripts/unsetvars.bsh
+++ b/src/test/resources/test-scripts/unsetvars.bsh
@@ -1,0 +1,25 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+// Test that variables can be unset
+
+bsh.system.abcd = 2;
+assertEquals(2, bsh.system.abcd);
+assert(isEvalError("Can't unset, not a variable: bsh.system.abcd.xyz", "unset('bsh.system.abcd.xyz');"));
+
+unset("bsh.system.abcd");
+assertTrue(bsh.system.abcd == void);
+
+bsh.system.abcd.xyz = 22;
+assertEquals(22, bsh.system.abcd.xyz);
+
+unset("bsh.system.abcd.xyz");
+assertTrue(bsh.system.abcd.xyz == void);
+assertFalse(bsh.system.abcd == void);
+
+unset("bsh.system.abcd");
+assertTrue(bsh.system.abcd == void);
+
+complete();


### PR DESCRIPTION
Fixes #497 allow changing prompt and prompt function
Fixes #505 unset to properly unset variables
Also fixes problem with loading .bshrc file
Fix repl resources not being closed
Fix debug output before console is set