### PR TITLE
Hidden field access on super classes

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Sat Jan 07 06:08:05 SAST 2023
-build=2932
+#Sat Jan 07 19:04:45 SAST 2023
+build=3095
 release=${project.version}

--- a/src/main/java/bsh/BSHTypedVariableDeclaration.java
+++ b/src/main/java/bsh/BSHTypedVariableDeclaration.java
@@ -86,7 +86,7 @@ class BSHTypedVariableDeclaration extends SimpleNode {
                         if ( null != namespace.classInstance )
                             lhs = new LHS(namespace.classInstance,
                                 Reflect.resolveJavaField(
-                                    namespace.classInstance.getClass(),
+                                    namespace.classStatic,
                                 dec.name, modifiers.hasModifier("static")));
                         else
                             lhs = new LHS(namespace.classStatic,

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -1210,10 +1210,14 @@ public class Interpreter
         Defaults to "bsh % " if the method is not defined or there is an error.
     */
     private String getBshPrompt() {
+        boolean dbg = DEBUG.get();
+        if (dbg) DEBUG.set(false);
         try {
             return (String) eval("getBshPrompt()");
         } catch ( Exception e ) {
             return "bsh % ";
+        } finally {
+            if (dbg) DEBUG.set(dbg);
         }
     }
 

--- a/src/main/java/bsh/NameSpace.java
+++ b/src/main/java/bsh/NameSpace.java
@@ -499,10 +499,17 @@ public class NameSpace
      * @param declaringInterpreter the declaring interpreter
      * @return the super */
     public This getSuper(final Interpreter declaringInterpreter) {
-        if (this.parent != null)
+        if (isClass && null != classStatic) { // get class super instance This
+            Class<?> zuper = classStatic.getSuperclass();
+            if (Reflect.isGeneratedClass(zuper))
+                return Reflect.getClassInstanceThis(classInstance, zuper.getSimpleName());
+        }
+        if (this.parent != null) {
+            if (this.parent.isClass)
+                return this.parent.getSuper(declaringInterpreter);
             return this.parent.getThis(declaringInterpreter);
-        else
-            return this.getThis(declaringInterpreter);
+        }
+        return this.getThis(declaringInterpreter);
     }
 
     /** Get the top level namespace or this namespace if we are the top. Note:

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -990,7 +990,7 @@ public final class Reflect {
             Object o = getObjectFieldValue(instance, BSHTHIS + className);
             return (This) Primitive.unwrap(o); // unwrap Primitive.Null to null
         } catch (Exception e) {
-            throw new InterpreterError("Generated class: Error getting This" + e, e);
+            throw new InterpreterError("Generated class: Error getting This " + e, e);
         }
     }
 

--- a/src/main/java/bsh/This.java
+++ b/src/main/java/bsh/This.java
@@ -544,8 +544,7 @@ public final class This implements java.io.Serializable, Runnable
     static boolean isExposedThisMethod( String name )
     {
         return
-            name.equals("getClass")
-            || name.equals("invokeMethod")
+            name.equals("invokeMethod")
             || name.equals("getInterface")
             // These are necessary to let us test synchronization from scripts
             || name.equals("wait")

--- a/src/main/java/bsh/Variable.java
+++ b/src/main/java/bsh/Variable.java
@@ -123,9 +123,7 @@ public class Variable implements java.io.Serializable
         A Variable can represent an LHS for the case of an imported class or
         object field.
     */
-    Object getValue()
-        throws UtilEvalError
-    {
+    Object getValue() throws UtilEvalError {
         if ( lhs != null )
             return type == null ?
                 lhs.getValue() : Primitive.wrap( lhs.getValue(), type );

--- a/src/test/java/bsh/InterpreterTest.java
+++ b/src/test/java/bsh/InterpreterTest.java
@@ -295,6 +295,22 @@ public class InterpreterTest {
     }
 
     @Test
+    public void no_debug_prompt_interpreter() throws Exception {
+        final StringReader in = new StringReader("\nInterpreter.DEBUG.set(true);\n");
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            CommandLineReader repl = new CommandLineReader(in) ) {
+            Interpreter bsh = new Interpreter(repl, new PrintStream(baos),
+                new PrintStream(baos), true);
+
+            bsh.setExitOnEOF(false);
+            bsh.run();
+            Interpreter.DEBUG.set(false);
+            assertTrue(baos.toString().contains("bsh %"));
+            assertEquals(2, baos.toString().split("Debug:").length);
+        }
+    }
+
+    @Test
     public void overwrite_get_prompt_exception() throws Exception {
         final StringReader in = new StringReader("\n");
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream() ) {

--- a/src/test/resources/test-scripts/class3.bsh
+++ b/src/test/resources/test-scripts/class3.bsh
@@ -93,8 +93,10 @@ assert( bar2.a == 5 );
 assert( bar2.q == 5 );
 assert( bar2.b2 == 99 );
 
-// Version 1.3 doesn't support this.
-assertEquals(99, ((Foo33)bar2).b2 );
+// Version 1.3 doesn't support this. Defunct since 3.0.0+
+//assertEquals(99, ((Foo33)bar2).b2 );
+// should return hidden field on Foo33 like JAVA does see #358
+assertEquals(42, ((Foo33)bar2).b2 );
 
 // subclass tests
 bar.barMethod();

--- a/src/test/resources/test-scripts/classsuper3.bsh
+++ b/src/test/resources/test-scripts/classsuper3.bsh
@@ -1,0 +1,76 @@
+source("TestHarness.bsh");
+source("Assert.bsh");
+/*
+    Make sure we can access super hidden fields
+*/
+
+class A {
+    String b = "abc"; // A.b
+    override() {
+        return "abc";
+    }
+}
+
+class B extends A {
+    String b = "xyz";   // hides super.b B.b
+    String a = super.b; // fetches super.b A.b
+    override() {
+        return "xyz";
+    }
+}
+
+class C extends B {
+    String b = "jkl";   // hides super.b C.b
+    String a = super.b; // hides super.a fetches super.b B.b
+    String c = super.a; // fetches super.a B.a which fetches super.b A.b
+    override() {
+        return "jkl";
+    }
+}
+
+class D extends C {
+    String b = ""; // hides super.b D.b
+    String a = ""; // hides super.a D.b
+    String c = ""; // hides super.c D.b
+
+    getB() {
+        return super.b; // C.b
+    }
+
+    getA() {
+        return super.a; // B.b
+    }
+
+    getC() {
+        return super.c; // A.b
+    }
+}
+
+c = new C();
+assertEquals("C's b field is C.b = jkl", "jkl", c.b);
+assertEquals("C's super.b field is B.b = xyz", "xyz", c.a);
+assertEquals("C's super.a B's super.b is A.b = abc", "abc", c.c);
+
+d = new D();
+assertEquals("D hides b", "", d.b);
+assertEquals("D hides a", "", d.a);
+assertEquals("D hides c", "", d.c);
+assertEquals("D get super.b via method is jkl", "jkl", d.getB());
+assertEquals("D get super.a via method is xyz", "xyz", d.getA());
+assertEquals("D get super.c via method is abc", "abc", d.getC());
+
+a = (A)new C();
+assertEquals("C cast as A so b = A.b = abc", "abc", a.b);
+assertEquals("C cast as A so a = C.a = xyz", "xyz", a.a);
+assertEquals("C cast as A so c = C.c = abc", "abc", a.c);
+assertEquals("C cast as A override() is C.override", "jkl", a.override());
+assertEquals("a.getClass = instance class", C.class, a.getClass());
+
+B b = (B)new C();
+assertEquals("C cast as B so b = B.b = xyz", "xyz", b.b);
+assertEquals("C cast as B so a = B.a = abc", "abc", b.a);
+assertEquals("C cast as B so c = C.c = abc", "abc", b.c);
+assertEquals("C cast as B override() is C.override", "jkl", b.override());
+assertEquals("b.getClass = instance class", C.class, b.getClass());
+
+complete();


### PR DESCRIPTION
Fixes #358 cast instance This for generated super type
Fixes #357 make super hidden variables ačcessible
Fixed get super namespace to include class namespace of parent classes not just scope
Cast to instance This and allow assignment to typed variable of cast type 
Instance this cast variable getClass reports the class of the instance
