### PR TITLE
Rewrite Modifiers to be JAVA compatible

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Sat Jan 07 19:04:45 SAST 2023
-build=3095
+#Mon Jan 09 22:29:25 SAST 2023
+build=3398
 release=${project.version}

--- a/src/main/java/bsh/BSHClassDeclaration.java
+++ b/src/main/java/bsh/BSHClassDeclaration.java
@@ -101,6 +101,9 @@ class BSHClassDeclaration extends SimpleNode
 
         BSHBlock block = (BSHBlock) jjtGetChild(child);
 
+        if (type == Type.INTERFACE) // this should ideally happen in the parser
+                modifiers.changeContext(Modifiers.INTERFACE);
+
         Class<?> clas = ClassGenerator.getClassGenerator().generateClass(
             name, modifiers, interfaces, superClass, block, type,
             callstack, interpreter );

--- a/src/main/java/bsh/BSHEnhancedForStatement.java
+++ b/src/main/java/bsh/BSHEnhancedForStatement.java
@@ -49,7 +49,7 @@ class BSHEnhancedForStatement extends SimpleNode implements ParserConstants {
 
 
     public Object eval(CallStack callstack, Interpreter interpreter) throws EvalError {
-        Modifiers modifiers = new Modifiers(Modifiers.FIELD);
+        Modifiers modifiers = new Modifiers(Modifiers.PARAMETER);
         if (this.isFinal)
             modifiers.addModifier("final");
         Class elementType = null;

--- a/src/main/java/bsh/BSHFormalParameters.java
+++ b/src/main/java/bsh/BSHFormalParameters.java
@@ -56,7 +56,7 @@ class BSHFormalParameters extends SimpleNode
             BSHFormalParameter param = (BSHFormalParameter)jjtGetChild(i);
             isVarArgs = param.isVarArgs;
             paramNames[i] = param.name;
-            paramModifiers[i] = new Modifiers(Modifiers.FIELD);
+            paramModifiers[i] = new Modifiers(Modifiers.PARAMETER);
             if (param.isFinal)
                 paramModifiers[i].addModifier("final");
         }

--- a/src/main/java/bsh/BSHTryStatement.java
+++ b/src/main/java/bsh/BSHTryStatement.java
@@ -125,7 +125,7 @@ class BSHTryStatement extends SimpleNode
                 {
                     // Get catch block
                     BSHMultiCatch mc = catchParams.get(i);
-                    Modifiers modifiers = new Modifiers(Modifiers.FIELD);
+                    Modifiers modifiers = new Modifiers(Modifiers.PARAMETER);
                     if (mc.isFinal())
                         modifiers.addModifier("final");
 

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -182,8 +182,9 @@ public class BshMethod implements Serializable, Cloneable {
     }
 
     public Modifiers getModifiers() {
-        if (this.modifiers == null)
+        if (this.modifiers == null) synchronized (this) {
             this.modifiers = new Modifiers(Modifiers.METHOD);
+        }
         return this.modifiers;
     }
 
@@ -523,7 +524,7 @@ public class BshMethod implements Serializable, Cloneable {
     public boolean hasModifier( String name ) {
         if ( javaMethod != null )
             return Reflect.hasModifier(name, javaMethod.getModifiers());
-        return modifiers != null && modifiers.hasModifier(name);
+        return getModifiers().hasModifier(name);
     }
 
     public String toString() {

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -182,9 +182,8 @@ public class BshMethod implements Serializable, Cloneable {
     }
 
     public Modifiers getModifiers() {
-        if (this.modifiers == null) synchronized (this) {
+        if (this.modifiers == null)
             this.modifiers = new Modifiers(Modifiers.METHOD);
-        }
         return this.modifiers;
     }
 
@@ -524,7 +523,7 @@ public class BshMethod implements Serializable, Cloneable {
     public boolean hasModifier( String name ) {
         if ( javaMethod != null )
             return Reflect.hasModifier(name, javaMethod.getModifiers());
-        return getModifiers().hasModifier(name);
+        return modifiers != null && modifiers.hasModifier(name);
     }
 
     public String toString() {

--- a/src/main/java/bsh/ClassGeneratorUtil.java
+++ b/src/main/java/bsh/ClassGeneratorUtil.java
@@ -145,9 +145,11 @@ public class ClassGeneratorUtil implements Opcodes {
         List<DelayedEvalBshMethod> methodsl = new ArrayList<>();
         String classBaseName = Types.getBaseName(className); // for inner classes
         for (DelayedEvalBshMethod bshmethod : bshmethods)
-            if (bshmethod.getName().equals(classBaseName))
+            if (bshmethod.getName().equals(classBaseName)) {
+                if (!bshmethod.modifiers.isAppliedContext(Modifiers.CONSTRUCTOR))
+                    bshmethod.modifiers.changeContext(Modifiers.CONSTRUCTOR);
                 consl.add(bshmethod);
-            else
+            } else
                 methodsl.add(bshmethod);
 
         constructors = consl.toArray(new DelayedEvalBshMethod[consl.size()]);
@@ -298,28 +300,28 @@ public class ClassGeneratorUtil implements Opcodes {
 
     /**
      * Translate bsh.Modifiers into ASM modifier bitflags.
+     * Only a subset of modifiers are baked into classes.
      */
     private static int getASMModifiers(Modifiers modifiers) {
         int mods = 0;
-        if (modifiers == null)
-            return mods;
 
-        if (modifiers.hasModifier("public"))
-            mods += ACC_PUBLIC;
-        if (modifiers.hasModifier("private"))
-            mods += ACC_PRIVATE;
-        if (modifiers.hasModifier("protected"))
-            mods += ACC_PROTECTED;
-        if (modifiers.hasModifier("static"))
-            mods += ACC_STATIC;
-        if (modifiers.hasModifier("synchronized"))
-            mods += ACC_SYNCHRONIZED;
-        if (modifiers.hasModifier("abstract"))
-            mods += ACC_ABSTRACT;
-
-        if ( ( mods & ACCESS_MODIFIERS ) == 0 ) {
+        if (modifiers.hasModifier(ACC_PUBLIC))
             mods |= ACC_PUBLIC;
-            modifiers.addModifier("public");
+        if (modifiers.hasModifier(ACC_PRIVATE))
+            mods |= ACC_PRIVATE;
+        if (modifiers.hasModifier(ACC_PROTECTED))
+            mods |= ACC_PROTECTED;
+        if (modifiers.hasModifier(ACC_STATIC))
+            mods |= ACC_STATIC;
+        if (modifiers.hasModifier(ACC_SYNCHRONIZED))
+            mods |= ACC_SYNCHRONIZED;
+        if (modifiers.hasModifier(ACC_ABSTRACT))
+            mods |= ACC_ABSTRACT;
+
+        // if no access modifiers declared then we make it public
+        if ( ( modifiers.getModifiers() & ACCESS_MODIFIERS ) == 0 ) {
+            mods |= ACC_PUBLIC;
+            modifiers.addModifier(ACC_PUBLIC);
         }
 
         return mods;

--- a/src/main/java/bsh/DelayedEvalBshMethod.java
+++ b/src/main/java/bsh/DelayedEvalBshMethod.java
@@ -89,6 +89,7 @@ public class DelayedEvalBshMethod extends BshMethod
              null, null);
 
         this.constructor = con;
+        this.modifiers = new Modifiers(Modifiers.CONSTRUCTOR);
         this.getModifiers().addModifier("public");
         this.getParameterModifiers();
         declaringNameSpace.setMethod(this);

--- a/src/main/java/bsh/Modifiers.java
+++ b/src/main/java/bsh/Modifiers.java
@@ -1,126 +1,206 @@
-/*****************************************************************************
- * Licensed to the Apache Software Foundation (ASF) under one                *
- * or more contributor license agreements.  See the NOTICE file              *
- * distributed with this work for additional information                     *
- * regarding copyright ownership.  The ASF licenses this file                *
- * to you under the Apache License, Version 2.0 (the                         *
- * "License"); you may not use this file except in compliance                *
- * with the License.  You may obtain a copy of the License at                *
- *                                                                           *
- *     http://www.apache.org/licenses/LICENSE-2.0                            *
- *                                                                           *
- * Unless required by applicable law or agreed to in writing,                *
- * software distributed under the License is distributed on an               *
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
- * KIND, either express or implied.  See the License for the                 *
- * specific language governing permissions and limitations                   *
- * under the License.                                                        *
- *                                                                           *
- *                                                                           *
- * This file is part of the BeanShell Java Scripting distribution.           *
- * Documentation and updates may be found at http://www.beanshell.org/       *
- * Patrick Niemeyer (pat@pat.net)                                            *
- * Author of Learning Java, O'Reilly & Associates                            *
- *                                                                           *
- *****************************************************************************/
+/** Copyright 2023 Nick nickl- Lombard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
 package bsh;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
 
-/**
-
-    @author Pat Niemeyer (pat@pat.net)
-*/
-/*
-    Note: which of these things should be checked at parse time vs. run time?
-*/
-public class Modifiers implements java.io.Serializable
-{
+/** Bsh equivalent and compatible, for the most part, with JAVA's Modifiers.
+ * The JAVA Modifier class does not include default as a modifier for methods
+ * and although it does define enum as a modifier, albeit not accessible, it
+ * does not include it as a valid field modifier. For these we were obligated
+ * to make accommodations for. */
+public class Modifiers implements java.io.Serializable {
     private static final long serialVersionUID = 1L;
-    public static final int CLASS=0, METHOD=1, FIELD=2;
-    private final int context;
-    private final List<String> modifiers = new ArrayList<>();
+    public static final int CLASS=0, INTERFACE=1, METHOD=2, FIELD=3, PARAMETER=4, CONSTRUCTOR=5;
+    public static final Map<String, Integer> CONST = new HashMap<>(17);
+    static {
+        CONST.put("public", Modifier.PUBLIC);
+        CONST.put("private", Modifier.PRIVATE);
+        CONST.put("protected", Modifier.PROTECTED);
+        CONST.put("static", Modifier.STATIC);
+        CONST.put("final", Modifier.FINAL);
+        CONST.put("synchronized", Modifier.SYNCHRONIZED);
+        CONST.put("volatile", Modifier.VOLATILE);
+        CONST.put("transient", Modifier.TRANSIENT);
+        CONST.put("native", Modifier.NATIVE);
+        CONST.put("interface", Modifier.INTERFACE);
+        CONST.put("abstract", Modifier.ABSTRACT);
+        CONST.put("strict", Modifier.STRICT);
+        CONST.put("synthetic", 4096);
+        CONST.put("annotation", 8192);
+        CONST.put("enum", 16384);  // not visible from Modifier
+        CONST.put("mandated", 32768);
+        CONST.put("default", 65536); // not included in Modifier
+    }
+    private static final int ACCESS_MODIFIERS = 7;
+    private String type;
+    private int valid, context, modifiers = 0;
 
+    /** Default constructor specifying the context these modifiers apply to.
+     * @param context identifier for the application of modifiers */
     public Modifiers(int context) {
-        this.context = context;
+        appliedContext(context);
     }
 
-    /**
-        @param context is METHOD or FIELD
-    */
-    public void addModifier( String name )
-    {
-        if ( modifiers.contains( name ) )
-            throw new IllegalStateException("Duplicate modifier: "+ name );
-        if (name.equals("public")||name.equals("protected")||name.equals("private"))
-            modifiers.add(0, name);
-        else
-            modifiers.add(name);
+    /** Add a modifier by modifier name. Will do a constant lookup to retrieve
+     * the integer bitwise specifier corresponding te the name.
+     * @param name the string name of the modifier to add. */
+    public void addModifier( String name ) {
+        addModifier(toModifier(name));
+    }
 
-        int count = 0;
-        if ( hasModifier("private") ) ++count;
-        if ( hasModifier("protected") ) ++count;
-        if ( hasModifier("public") ) ++count;
-        if ( count > 1 )
-            throw new IllegalStateException(
-                "public/private/protected cannot be used in combination." );
+    /** Add modifier by unique identifier number. The validity of the identifier
+     * applicable to this context is verified and whether only one of the access
+     * modifiers public, private, or protected is used which will result in an
+     * IllegalStateException thrown if failed.
+     * The duplicate check has been removed because the mathematical assignment
+     * will simply roll duplicates in automatically, as apposed to maintaining a
+     * list of names.
+     * @param mod unique bit definition for a modifier to apply */
+    public void addModifier( int mod ) {
+        if ((valid & mod) == 0)
+            throw new IllegalStateException(type + " cannot be declared '" + toModifier(mod) + "'");
+        else if (mod < ACCESS_MODIFIERS && (modifiers & ACCESS_MODIFIERS) > 0 && (modifiers | mod) != modifiers)
+            throw new IllegalStateException("public/private/protected cannot be used in combination." );
+        modifiers |= mod;
+    }
 
-        switch( context )
-        {
-        case CLASS:
-            validateForClass();
-            break;
-        case METHOD:
-            validateForMethod();
-            break;
-        case FIELD:
-            validateForField();
-            break;
+    /** Add multiple modifiers defined by a destinct bit definition. We can itterate
+     * through the supplied definition and mathematically detect which modifiers are
+     * to be added one by one.
+     * @param mods distinct bit definition of modifiers to apply */
+    public void addModifiers(int mods) {
+        for (int mod = 1; mod <= mods; mod *= 2)
+            if ((mods & mod) != 0)
+                addModifier(mod);
+    }
+
+    /** Retrieve the distinct bit definition of all applied modifiers. This value
+     * can be decoded with the Modifier class as it is compatible with the modifiers
+     * returned from Class or Member.
+     * @return distinct bit definition of applied modifiers */
+    public int getModifiers() {
+        return modifiers;
+    }
+
+    /** Change the current applied context and revalidate the modifiers. This allows
+     * us to capture modifiers in one context then later change the context without
+     * loosing the existing modifiers which are also applicable to the new context.
+     * @param context identifier for the application of modifiers */
+    public void changeContext(int context) {
+        int mods = modifiers;
+        modifiers = 0;
+        appliedContext(context);
+        addModifiers(mods);
+    }
+
+    /** Verify whether the expected application context is configured. Used to ensure
+     * the expected context has been configured for the purpose, before changing the
+     * context unecessarily.
+     * @param context the query to verify
+     * @return true if the supplied context is cenfigured. */
+    public boolean isAppliedContext(int context) {
+        return this.context == context;
+    }
+
+    /** Query whether the modifier has been applied.
+     * @param name modifier name for lookup
+     * @return true if modifier is applied */
+    public boolean hasModifier( String name ) {
+        return hasModifier(toModifier(name));
+    }
+
+    /** Query whether the modifier has been applied.
+     * @param mod unique modifier bit value for lookup
+     * @return true if modifier is applied */
+    public boolean hasModifier( int mod ) {
+        return (modifiers & mod) != 0;
+    }
+
+    /** Convenience method to assign modifiers for a constant definition. */
+    public void setConstant() {
+        modifiers = Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL;
+    }
+
+    /** Configures the applied context for these modifiers. For each context there is
+     * a destinct bit definition that corresponds to the valid or allowed modifiers
+     * applicable. The type name of the context is kept for informative error reporting.
+     * @param context identifier for the application of modifiers */
+    private void appliedContext(int context) {
+        this.context = context;
+        switch( context ) {
+            case CLASS:
+                valid = Modifier.classModifiers();
+                type = "Class";
+                break;
+            case INTERFACE:
+                valid = Modifier.interfaceModifiers();
+                type = "Interface";
+                break;
+            case METHOD:
+                valid = Modifier.methodModifiers() | CONST.get("default");
+                type = "Method";
+                break;
+            case FIELD:
+                valid = Modifier.fieldModifiers() | CONST.get("enum");
+                type = "Field";
+                break;
+            case PARAMETER:
+                valid = Modifier.parameterModifiers();
+                type = "Parameter";
+                break;
+            case CONSTRUCTOR:
+                valid = Modifier.constructorModifiers();
+                type = "Constructor";
+                break;
+            default:
+                valid = 0;
+                type = "Unknown";
         }
     }
 
-    public boolean hasModifier( String name )
-    {
-        return modifiers.contains(name);
+    /** Modifier name to distinct bit value lookup. If the name is not found it
+     * is considered unknown and an IllegalStateException will be thrown.
+     * @param name the modifier name
+     * @return corresponding bit value */
+    private int toModifier(String name) {
+        Integer mod = CONST.get(name);
+        if (null == mod)
+            throw new IllegalStateException("Unknown modifier: '" + name + "'");
+        return mod.intValue();
     }
 
-    // could refactor these a bit
-    private void validateForMethod()
-    {
-        insureNo("volatile", "Method");
-        insureNo("transient", "Method");
-    }
-    private void validateForField()
-    {
-        insureNo("synchronized", "Variable");
-        insureNo("native", "Variable");
-        insureNo("abstract", "Variable");
-    }
-    private void validateForClass()
-    {
-        validateForMethod(); // volatile, transient
-        insureNo("native", "Class");
-        insureNo("synchronized", "Class");
+    /** Distinct bit identifier to modifier name lookup, This is a convenience
+     * method to produce a legible form of a modifier and is not relied upon to
+     * produce a valid answer. If no corresponding name was found a string value
+     * of the number is returned.
+     * @param mod the bit value of a modifier
+     * @return corresponding modifier name */
+    private String toModifier(int mod) {
+        for (String name:CONST.keySet())
+            if (mod == CONST.get(name))
+                return name;
+        return String.valueOf(mod);
     }
 
-    private void insureNo( String modifier, String context )
-    {
-        if ( hasModifier( modifier ) )
-            throw new IllegalStateException(
-                context + " cannot be declared '"+modifier+"'");
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "Modifiers: " + Modifier.toString(modifiers) + (
+            (modifiers & CONST.get("enum")) != 0 ? " enum" :
+            (modifiers & CONST.get("default")) != 0 ? " default" : "");
     }
-
-    public void setConstant() {
-        modifiers.clear();
-        addModifier("public");
-        addModifier("static");
-        addModifier("final");
-    }
-
-    public String toString()
-    {
-        return "Modifiers: "+String.join(" ", modifiers);
-    }
-
 }

--- a/src/main/java/bsh/ParseException.java
+++ b/src/main/java/bsh/ParseException.java
@@ -130,17 +130,18 @@ public class ParseException extends EvalError {
      */
     private static String initialise(Token currentToken, int[][] expectedTokenSequences, String[] tokenImage) {
         StringBuilder retval = new StringBuilder("Unable to parse code syntax. Encountered:");
-        Token tok = currentToken;
-        while (null != (tok = tok.next))
-            retval.append(" ").append(add_escapes(tok.image));
+        if (null != currentToken) {
+            Token tok = currentToken;
+            while (null != (tok = tok.next))
+                retval.append(" ").append(add_escapes(tok.image));
 
-        retval.append(" at line ")
-            .append(currentToken.next.beginLine)
-            .append(", column ")
-            .append(currentToken.next.beginColumn);
-        if (null != sourceFile)
-            retval.append(" in: ").append(sourceFile);
-
+            retval.append(" at line ")
+                .append(currentToken.next.beginLine)
+                .append(", column ")
+                .append(currentToken.next.beginColumn);
+            if (null != sourceFile)
+                retval.append(" in: ").append(sourceFile);
+        }
         if (Interpreter.DEBUG.get() && expectedTokenSequences.length != 0) {
             retval.append(System.getProperty("line.separator", "\n")).append("Exppected");
             if (expectedTokenSequences.length > 1)

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -1210,7 +1210,7 @@ public final class Reflect {
         try {
             return (Modifiers)getVariable(type, BSHCLASSMODIFIERS.toString()).getValue();
         } catch (Exception e) {
-            return new Modifiers(Modifiers.CLASS);
+            return new Modifiers(type.isInterface() ? Modifiers.INTERFACE : Modifiers.CLASS);
         }
     }
 

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -1064,13 +1064,20 @@ public final class Reflect {
     }
 
     /*
-     * Get method from namespace
+     * Get declared method from namespace
      */
     public static BshMethod getMethod(NameSpace ns, String name, Class<?>[] sig) {
+        return getMethod(ns, name, sig, true);
+    }
+
+    /*
+     * Get method from namespace
+     */
+    public static BshMethod getMethod(NameSpace ns, String name, Class<?>[] sig, boolean declaredOnly) {
         if (null == ns)
             return null;
         try {
-            return ns.getMethod(name, sig, true);
+            return ns.getMethod(name, sig, declaredOnly);
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -841,7 +841,7 @@ public final class Reflect {
         for ( Entry ntre : entries )
             if ( key.equals(ntre.getKey()) )
                 return ntre;
-        throw new ReflectError("No such property: " + key);
+        return null;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -1255,11 +1255,11 @@ public final class Reflect {
     }
 
     public static boolean isStatic(Member member) {
-        return member != null && Modifier.isStatic(member.getModifiers());
+        return Modifier.isStatic(member.getModifiers());
     }
 
     public static boolean isStatic(Class<?> clazz) {
-        return clazz != null && Modifier.isStatic(clazz.getModifiers());
+        return Modifier.isStatic(clazz.getModifiers());
     }
 
     public static boolean hasModifier(String name, int modifiers) {

--- a/src/main/java/bsh/This.java
+++ b/src/main/java/bsh/This.java
@@ -219,11 +219,8 @@ public final class This implements java.io.Serializable, Runnable
                 otherwise callers from outside in Java will not see a the
                 proxy object as equal to itself.
             */
-            BshMethod equalsMethod = null;
-            try {
-                equalsMethod = namespace.getMethod(
-                    "equals", new Class<?>[] { Object.class } );
-            } catch ( UtilEvalError e ) {/*leave null*/ }
+            BshMethod equalsMethod = Reflect.getMethod(
+                namespace, "equals", new Class<?>[] { Object.class } );
             if ( methodName.equals("equals" ) && equalsMethod == null ) {
                 Object obj = args[0];
                 return proxy == obj;
@@ -233,14 +230,10 @@ public final class This implements java.io.Serializable, Runnable
                 If toString() is not explicitly defined override the default
                 to show the proxy interfaces.
             */
-            BshMethod toStringMethod = null;
-            try {
-                toStringMethod =
-                    namespace.getMethod( "toString", new Class<?>[] { } );
-            } catch ( UtilEvalError e ) {/*leave null*/ }
+            BshMethod toStringMethod = Reflect.getMethod(
+                namespace, "toString", new Class<?>[] { } );
 
-            if ( methodName.equals("toString" ) && toStringMethod == null)
-            {
+            if ( methodName.equals("toString" ) && toStringMethod == null) {
                 Class<?>[] ints = proxy.getClass().getInterfaces();
                 // XThis.this refers to the enclosing class instance
                 StringBuilder sb = new StringBuilder(
@@ -268,6 +261,10 @@ public final class This implements java.io.Serializable, Runnable
     }
 
     public String toString() {
+        BshMethod toString = Reflect.getMethod(namespace, "toString", new Class<?>[0]);
+        if (null != toString) try {
+            return (String)toString.invoke(new Object[0], declaringInterpreter);
+        } catch (EvalError e) { /* ignore we tried */ }
         return "'this' reference to Bsh object: " + namespace;
     }
 
@@ -381,10 +378,8 @@ public final class This implements java.io.Serializable, Runnable
 
         // Find the bsh method
         Class<?>[] types = Types.getTypes( args );
-        BshMethod bshMethod = null;
-        try {
-            bshMethod = namespace.getMethod( methodName, types, declaredOnly );
-        } catch ( UtilEvalError e ) { /*leave null*/ }
+        BshMethod bshMethod = Reflect.getMethod(
+            namespace, methodName, types, declaredOnly );
 
         if ( bshMethod != null )
             return bshMethod.invoke( args, interpreter, callstack, callerInfo );
@@ -401,7 +396,7 @@ public final class This implements java.io.Serializable, Runnable
         */
         // a default getClass() that returns the namespace instance class
         if ( methodName.equals("getClass") && args.length==0 )
-            return This.class;
+            return getClass();
 
         // a default toString() that shows the interfaces we implement
         if ( methodName.equals("toString") && args.length==0 )
@@ -418,22 +413,20 @@ public final class This implements java.io.Serializable, Runnable
         }
 
         // a default clone() method
-        if ( methodName.equals("clone") && args.length==0 ) {
+        if ( methodName.equals("clone") && args.length==0 )
             return cloneMethodImpl(callerInfo, callstack);
-        }
 
         // Look for a default invoke() handler method in the namespace
         boolean[] outHasMethod = new boolean[1];
         Object result = namespace.invokeDefaultInvokeMethod(methodName, args,
                 interpreter, callstack, callerInfo, outHasMethod);
-        if ( outHasMethod[0] )
-            return result;
+        if ( outHasMethod[0] ) return result;
 
         // Finally look for any command in this namespace that might qualify
         try {
             return namespace.invokeCommand(
                     methodName, args, interpreter, callstack, callerInfo, true);
-          } catch (EvalError e) {
+        } catch (EvalError e) {
              throw new EvalError("Method " +
                     StringUtil.methodString( methodName, types ) +
                     " not found in bsh scripted object: "+ namespace.getName(),
@@ -681,7 +674,8 @@ public final class This implements java.io.Serializable, Runnable
                 args = This.CONTEXT_ARGS.get().remove(instance.toString());
 
             // Find the constructor (now in the instance namespace)
-            BshMethod constructor = instanceNameSpace.getMethod(Types.getBaseName(className), Types.getTypes(args), true/*declaredOnly*/);
+            BshMethod constructor = instanceNameSpace.getMethod(
+                Types.getBaseName(className), Types.getTypes(args), true/*declaredOnly*/);
 
             // if args, we must have constructor
             if (args.length > 0 && constructor == null)

--- a/src/test/java/bsh/ReflectTest.java
+++ b/src/test/java/bsh/ReflectTest.java
@@ -473,6 +473,12 @@ public class ReflectTest {
     }
 
     @Test
+    public void get_class_modifiers_for_interfage() throws Exception {
+        assertTrue("Modifiers of context INTERFACE",
+            Reflect.getClassModifiers(Runnable.class).isAppliedContext(Modifiers.INTERFACE));
+    }
+
+    @Test
     public void get_declared_variables_from_class() throws Exception {
         Class<?> type = (Class<?>) eval(
                 "class T20 {",

--- a/src/test/java/bsh/ReflectTest.java
+++ b/src/test/java/bsh/ReflectTest.java
@@ -8,15 +8,20 @@ import org.junit.runner.RunWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -470,6 +475,160 @@ public class ReflectTest {
         assertThat("variables has [sv3, v3]",
                 Stream.of(vars).map(Variable::getName).collect(Collectors.toList()),
                 hasItems("sv3", "v3"));
+    }
+
+    @Test
+    public void get_method_from_null_namespace() throws Exception {
+        assertThat("null namespace", Reflect.getMethod(
+            (NameSpace)null, null, null), nullValue());
+    }
+
+    @Test
+    public void get_method_names_from_null_namespace() throws Exception {
+        assertThat("null namespace", Reflect.getMethodNames(
+            (NameSpace)null), arrayWithSize(0));
+    }
+
+    @Test
+    public void get_variable_names_from_null_namespace() throws Exception {
+        assertThat("null namespace", Reflect.getVariableNames(
+            (NameSpace)null), arrayWithSize(0));
+    }
+
+    @Test
+    public void get_declared_method_from_null_class() throws Exception {
+        assertThat("null class", Reflect.getDeclaredMethod(
+            (Class<?>)null, null, null), nullValue());
+    }
+
+    @Test
+    public void get_declared_method_from_java_class() throws Exception {
+        assertThat("java class", Reflect.getDeclaredMethod(
+            Object.class, null, null), nullValue());
+    }
+
+    @Test
+    public void get_declared_method_from_generated_class() throws Exception {
+        assertThat("null mehdod", Reflect.getDeclaredMethod(
+            GeneratedClass.class, null, null), nullValue());
+    }
+
+    @Test
+    public void get_declared_methods_from_generated_class() throws Exception {
+        assertThat("list of mehods", Reflect.getDeclaredMethods(
+            GeneratedClass.class), arrayWithSize(0));
+    }
+
+    @Test
+    public void get_declared_method_from_generated_interface() throws Exception {
+        Class<?> claz = (Class<?>) eval(
+            "interface Intr {}",
+            "return Intr.class;"
+        );
+        assertThat("null method", Reflect.getDeclaredMethod(
+            claz, "abc", new Class<?>[0]), nullValue());
+    }
+
+    @Test
+    public void get_declared_variable_from_generated_class() throws Exception {
+        assertThat("null variable", Reflect.getDeclaredVariable(
+            GeneratedClass.class, null), nullValue());
+    }
+
+    @Test
+    public void get_declared_variables_from_generated_class() throws Exception {
+        assertThat("list of variables", Reflect.getDeclaredVariables(
+            GeneratedClass.class), arrayWithSize(0));
+    }
+
+    @Test
+    public void get_declared_variable_from_generated_interface() throws Exception {
+        Class<?> claz = (Class<?>) eval(
+            "interface Intr {}",
+            "return Intr.class;"
+        );
+        assertThat("null variable", Reflect.getDeclaredVariable(
+            claz, "abc"), nullValue());
+    }
+
+    @Test
+    public void get_declared_variables_from_null_namespace() throws Exception {
+        assertThat("list of variables", Reflect.getVariables(
+            null, null), arrayWithSize(0));
+    }
+
+    public void get_declared_variables_from_null_names() throws Exception {
+        assertThat("list of variables", Reflect.getVariables(
+            new NameSpace("abc"), null), arrayWithSize(0));
+    }
+
+    public void is_private_from_to_string() throws Exception {
+        assertFalse("to string is not private",
+            Reflect.isPrivate(getClass().getMethod("toString", new Class<?>[0])));
+    }
+
+    @Test
+    public void constuct_objuct_from_null_class() throws Exception {
+        Object out = Reflect.constructObject((Class<?>)null, null, null);
+        assertThat("object is primitive null", out, equalTo(Primitive.NULL));
+    }
+
+    @Test
+    public void resolve_java_method_from_null_class() throws Exception {
+        Exception e = assertThrows(InterpreterError.class, () ->
+            Reflect.resolveJavaMethod(null, null, null, false));
+        assertThat("exception message contains", e.getMessage(),
+            containsString("null class"));
+    }
+
+    @Test
+    public void constuct_objuct_from_interface() throws Exception {
+        Exception e = assertThrows(ReflectError.class, () ->
+            Reflect.constructObject(Runnable.class, null, null));
+        assertThat("exception message contains", e.getMessage(),
+            containsString("Can't create instance of an interface"));
+    }
+
+    @Test
+    public void resolve_java_method_null_object() throws Exception {
+        Exception e = assertThrows(UtilTargetError.class, () ->
+            Reflect.getObjectFieldValue(Primitive.NULL, "abc"));
+        assertThat("exception message contains", e.getMessage(),
+            containsString("Attempt to access field 'abc' on null value"));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void set_object_property_no_entry_key() throws Exception {
+        Entry entr = (Entry) eval("return new Entry {'efg'=4}[0];");
+        Exception e = assertThrows(ReflectError.class, () ->
+            Reflect.setObjectProperty(entr, "abc", 2));
+        assertThat("exception message contains", e.getMessage(),
+            containsString("No such property setter: abc"));
+    }
+
+    @Test
+    public void modifier_unknown() throws Exception {
+        Exception e = assertThrows(IllegalStateException.class, () ->
+            new Modifiers(Modifiers.PARAMETER).addModifier("snazzy"));
+        assertThat("exception message contains", e.getMessage(),
+            containsString("Unknown modifier: 'snazzy'"));
+    }
+
+    @Test
+    public void modifier_cannot_declare() throws Exception {
+        Exception e = assertThrows(IllegalStateException.class, () ->
+            new Modifiers(Modifiers.PARAMETER).addModifier(0));
+        assertThat("exception message contains", e.getMessage(),
+            containsString("Parameter cannot be declared '0'"));
+    }
+
+    @Test
+    public void modifier_unknown_cannot_declare() throws Exception {
+        Exception e = assertThrows(IllegalStateException.class, () ->
+            new Modifiers(99).addModifier("public"));
+        assertThat("exception message contains", e.getMessage(),
+            containsString("Unknown cannot be declared 'public'"));
     }
 
     @Test

--- a/src/test/resources/test-scripts/expression_entry.bsh
+++ b/src/test/resources/test-scripts/expression_entry.bsh
@@ -174,9 +174,9 @@ assertNotNull(entries["m"]);
 assertEquals(4, entries["m"]);
 assertEquals(3, entries.length);
 assert(isEvalError("cannot assign number 2147483648 to type int", "entries[2147483648]"));
-assert(isEvalError("No such property: xx", "entries['xx']"));
-assert(isEvalError("No such property: 5", "entries[5]"));
-assert(isEvalError("No such property: -5", "entries[-5]"));
+assert(void == entries['xx']);
+assert(void == entries[5]);
+assert(void == entries[-5]);
 
 // nested entry arrays
 entries = new Entry {"k"=3};

--- a/src/test/resources/test-scripts/expression_map.bsh
+++ b/src/test/resources/test-scripts/expression_map.bsh
@@ -66,6 +66,7 @@ assertThat(map, valueString('{123I=5I}'));
 map[a] = 456;
 assertThat(map[a], equalTo(456));
 assertThat(map[123], equalTo(456));
+assert(map["123"] == void);
 assertThat(map, valueString('{123I=456I}'));
 assertThat(map, instanceOf(Map.class));
 

--- a/src/test/resources/test-scripts/modifiers.bsh
+++ b/src/test/resources/test-scripts/modifiers.bsh
@@ -1,5 +1,7 @@
 #!/bin/java bsh.Interpreter
 
+import bsh.Reflect;
+
 source("TestHarness.bsh");
 
 private int bar() { }
@@ -8,22 +10,43 @@ private int bar() { }
 private synchronized int bar() { }
 private synchronized bar() { }
 private synchronized final bar() { }
-assert( isEvalError("private private int bar() { }") );
-assert( isEvalError("private private bar() { }") );
-assert( isEvalError("private public int bar() { }") );
-assert( isEvalError("private public bar() { }") );
-assert( isEvalError("volatile int bar() { }") );
+assert( Reflect.getMethod(global.namespace, 'bar', new Class[0]).getModifiers().hasModifier('final'));
+assert( Reflect.getMethod(global.namespace, 'bar', new Class[0]).getModifiers().hasModifier('synchronized'));
+assert( Reflect.getMethod(global.namespace, 'bar', new Class[0]).getModifiers().hasModifier('private'));
+private private int bar() { } // duplicates are rolled in
+assert( Reflect.getMethod(global.namespace, 'bar', new Class[0]).getModifiers().hasModifier('private'));
+assert( isEvalError("public/private/protected cannot be used in combination.", "private protected bar() { }") );
+assert( isEvalError("public/private/protected cannot be used in combination.", "private public int bar() { }") );
+public public bar() { } // duplicates are rolled in
+assert( Reflect.getMethod(global.namespace, 'bar', new Class[0]).getModifiers().hasModifier('public'));
+assert( isEvalError("public/private/protected cannot be used in combination.", "public private bar() { }") );
+assert( isEvalError("public/private/protected cannot be used in combination.", "public protected bar() { }") );
+protected protected bar() { } // duplicates are rolled in
+assert( Reflect.getMethod(global.namespace, 'bar', new Class[0]).getModifiers().hasModifier('protected'));
+assert( isEvalError("public/private/protected cannot be used in combination.", "protected public bar() { }") );
+assert( isEvalError("public/private/protected cannot be used in combination.", "protected private bar() { }") );
+assert( isEvalError("Method cannot be declared 'volatile'", "volatile int bar() { }") );
 
 int foo;
 int foo2=5;
-private int foo3;
 private final int foo3;
 private int foo4=5;
 private int foo5;
 private volatile int foo6;
 private volatile int foo7 = 2;
-assert( isEvalError("synchronized int bar20") );
-assert( isEvalError("public private int bar21") );
+assert( Reflect.getVariable(global.namespace, 'foo6').getModifiers().hasModifier('volatile'));
+assert( Reflect.getVariable(global.namespace, 'foo7').getModifiers().hasModifier('private'));
+assert( Reflect.getVariable(global.namespace, 'foo3').getModifiers().hasModifier('final'));
+assert( isEvalError("Field cannot be declared 'synchronized'", "synchronized int bar20") );
+assert( isEvalError("public/private/protected cannot be used in combination.", "public private int bar21") );
+
+foo(final int bar) {
+    assert( Reflect.getVariable(this.namespace, 'bar').getModifiers().hasModifier('final'));
+}
+foo(1);
+
+assert( isEvalError("Constructor cannot be declared 'static'", "class A { public static A() {} }"));
+assert( isEvalError("Constructor cannot be declared 'synchronized'", "class B { synchronized B() {} }"));
 
 final int fin = 1;
 assert( isEvalError("fin=2") );

--- a/src/test/resources/test-scripts/scripted_object.bsh
+++ b/src/test/resources/test-scripts/scripted_object.bsh
@@ -57,4 +57,14 @@ assertThat("Test equality of list item", c.ylds, hasItem(c.ylds.get(0)));
 assertThat("New reference only has one item in list", d.ylds, iterableWithSize(1));
 assertEquals("New reference assigned value", "goodbye", d.ylds.get(0).c);
 
+// scripted object overwrite toString #371
+
+overwriteToString() {
+   toString() {
+      return "I am overwriteToString";
+   }
+   return this;
+}
+assertEquals("I am overwriteToString", "" + overwriteToString());
+
 complete();


### PR DESCRIPTION
A drop in replacement still serves the same purpose, to capture modifier names through the parser but instead of storing the text in a collection the modifiers are translahe to their int values and stored as a distinct bit definition compatible with Modifier and ASM constants. Includes complete validation of applicable modifiers as defined by JAVA Modifier and includes additional contexts for INTERFARCE, PARAMETER, and CONSTRUCTOR, which was previously missing. Dropped duplicate modifier checks because the math will automatically roll duplicates in. Can process multiple modifier definitions and is capable of context change. Retained the hasModifier functionality can use with both name and bit identifier and will work with Modifier to decode the values as well.

Reflect coverage improvements

Allow scripted objects overwrite toString.
Fixes #371 adding a toString method to a scripted object will now be called instead of This.toString.

Conformance fix on Entry lists.
All other properties on BeanShell will return void if not found but Entry lists raises a No such property error.

Resolve NPE on ParseException.