### PR TITLE
Generate class

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Tue Jan 10 13:48:28 SAST 2023
-build=3577
+#Thu Jan 12 04:19:53 SAST 2023
+build=3670
 release=${project.version}

--- a/src/main/java/bsh/BSHAmbiguousName.java
+++ b/src/main/java/bsh/BSHAmbiguousName.java
@@ -57,7 +57,7 @@ class BSHAmbiguousName extends SimpleNode
         }
     }
 
-    public Class toClass( CallStack callstack, Interpreter interpreter )
+    public Class<?> toClass( CallStack callstack, Interpreter interpreter )
         throws EvalError
     {
         try {

--- a/src/main/java/bsh/BSHBlock.java
+++ b/src/main/java/bsh/BSHBlock.java
@@ -177,7 +177,7 @@ class BSHBlock extends SimpleNode {
     }
 
     public interface NodeFilter {
-        boolean isVisible( Node node );
+        public boolean isVisible( Node node );
     }
 
     @Override

--- a/src/main/java/bsh/BSHClassDeclaration.java
+++ b/src/main/java/bsh/BSHClassDeclaration.java
@@ -71,7 +71,7 @@ class BSHClassDeclaration extends SimpleNode
         int child = 0;
 
         // resolve superclass if any
-        Class superClass = null;
+        Class<?> superClass = null;
         final List<BshMethod> meths = new ArrayList<>(0);
         if ( extend ) {
             BSHAmbiguousName superNode = (BSHAmbiguousName)jjtGetChild(child++);
@@ -89,7 +89,7 @@ class BSHClassDeclaration extends SimpleNode
         }
 
         // Get interfaces
-        Class [] interfaces = new Class[numInterfaces];
+        Class<?>[] interfaces = new Class[numInterfaces];
         for( int i=0; i<numInterfaces; i++) {
             BSHAmbiguousName node = (BSHAmbiguousName)jjtGetChild(child++);
             interfaces[i] = node.toClass(callstack, interpreter);

--- a/src/main/java/bsh/BSHType.java
+++ b/src/main/java/bsh/BSHType.java
@@ -89,32 +89,22 @@ class BSHType extends SimpleNode implements BshClassManager.Listener {
         else
         {
             String clasName = ((BSHAmbiguousName)node).text;
-            BshClassManager bcm = interpreter.getClassManager();
-            // Note: incorrect here - we are using the hack in bsh class
-            // manager that allows lookup by base name.  We need to eliminate
-            // this limitation by working through imports.  See notes in class
-            // manager.
-            String definingClass = bcm.getClassBeingDefined( clasName );
+            String innerClass = callstack.top().importedClasses.get(clasName);
 
             Class<?> clas = null;
-            if ( definingClass == null )
-            {
-                try {
-                    clas = ((BSHAmbiguousName)node).toClass(
-                        callstack, interpreter );
-                } catch ( EvalError e ) {
-                    // Lets assume we have a generics raw type
-                    if (clasName.length() == 1)
-                        clasName = "java.lang.Object";
-                }
+            if ( innerClass == null ) try {
+                clas = ((BSHAmbiguousName)node).toClass(
+                    callstack, interpreter );
+            } catch ( EvalError e ) {
+                // Lets assume we have a generics raw type
+                if (clasName.length() == 1)
+                    clasName = "java.lang.Object";
             } else
-                clasName = definingClass;
+                clasName = innerClass.replace('.', '$');
 
-            if ( clas != null )
-            {
+            if ( clas != null ) {
                 descriptor = getTypeDescriptor( clas );
-            }else
-            {
+            } else {
                 if ( defaultPackage == null || Name.isCompound( clasName ) )
                     descriptor = "L" + clasName.replace('.','/') + ";";
                 else

--- a/src/main/java/bsh/BSHType.java
+++ b/src/main/java/bsh/BSHType.java
@@ -30,9 +30,7 @@ package bsh;
 
 import java.lang.reflect.Array;
 
-class BSHType extends SimpleNode
-    //implements BshClassManager.Listener
-{
+class BSHType extends SimpleNode implements BshClassManager.Listener {
     private static final long serialVersionUID = 1L;
     /**
         baseType is used during evaluation of full type and retained for the
@@ -171,17 +169,8 @@ class BSHType extends SimpleNode
         } else
             type = baseType;
 
-        // hack... sticking to first interpreter that resolves this
-        // see comments on type instance variable (in header on SimpleNode)
-        // -------
-        // This has been here since the first commit, not sure if it is only
-        // theoretical or an actual concern. Yes some blocks are reiterated
-        // processing nodes again but what would make a previously scripted,
-        // interpreted, and executed type change on the fly?
-        // Leaving this commented here for now as a reference if things go
-        // wrong but should it be removed one day it must go with the interface
-        // BshClassManager.Listener and contract method classLoaderChanged()
-//         interpreter.getClassManager().addListener(this);
+        // add listener to reload type if class is reloaded see #699
+        interpreter.getClassManager().addListener(this);
 
         return type;
     }
@@ -202,10 +191,11 @@ class BSHType extends SimpleNode
         return arrayDims;
     }
 
-//    public void classLoaderChanged() {
-//        type = null;
-//        baseType = null;
-//    }
+    /** Clear instance cache to reload types on class loader change #699 */
+    public void classLoaderChanged() {
+        type = null;
+        baseType = null;
+    }
 
     public static String getTypeDescriptor( Class<?> clas )
     {

--- a/src/main/java/bsh/ClassGenerator.java
+++ b/src/main/java/bsh/ClassGenerator.java
@@ -75,8 +75,6 @@ public final class ClassGenerator {
         String className = enclosingNameSpace.isClass ? (enclosingNameSpace.getName() + "$" + name) : name;
         String fqClassName = packageName == null ? className : packageName + "." + className;
         BshClassManager bcm = interpreter.getClassManager();
-        // Race condition here...
-        bcm.definingClass(fqClassName);
 
         // Create the class static namespace
         NameSpace classStaticNameSpace = new NameSpace(enclosingNameSpace, className);
@@ -132,8 +130,6 @@ public final class ClassGenerator {
         classStaticNameSpace.setClassStatic(genClass);
 
         Interpreter.debug(classStaticNameSpace);
-
-        bcm.doneDefiningClass(fqClassName);
 
         if (interpreter.getStrictJava())
             ClassGeneratorUtil.checkAbstractMethodImplementation(genClass);

--- a/src/test/resources/test-scripts/classreload.bsh
+++ b/src/test/resources/test-scripts/classreload.bsh
@@ -1,19 +1,31 @@
 #!/bin/java bsh.Interpreter
 
 source("TestHarness.bsh");
+source("Assert.bsh");
 
-assert( FooR == void );
+assertTrue( FooR == void );
 
 class FooR {
     public int get() { return 42; }
 }
-assert( new FooR().get() == 42 );
+assertEquals(42, new FooR().get());
 
 class FooR {
     public int get() { return 43; }
 }
-assert( new FooR().get() == 43 );
+assertEquals(43, new FooR().get());
 
 class BarR extends FooR { }
+
+assertEquals(43, new BarR().get());
+
+class FooR {
+    public int get() { return 44; }
+}
+assertEquals(44, new FooR().get());
+// TODO: this is wrong should be 44 #697
+assertEquals(43, new BarR().get());
+// TODO: this is wrong classes should be the same #697
+assertNotSame("FooR.class is same as FooR.class", FooR.class, BarR.class.getSuperclass());
 
 complete();

--- a/src/test/resources/test-scripts/classreload2.bsh
+++ b/src/test/resources/test-scripts/classreload2.bsh
@@ -1,0 +1,14 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+class A {}
+class A {
+    static A INSTANCE = new A();
+}
+
+// Works because BSHType listens for class reload events #699
+assertSame("A.class is A.class reloaded", A.class, A.INSTANCE.getClass());
+
+complete();

--- a/src/test/resources/test-scripts/classreload2.bsh
+++ b/src/test/resources/test-scripts/classreload2.bsh
@@ -3,7 +3,16 @@
 source("TestHarness.bsh");
 source("Assert.bsh");
 
+// TODO: this should somehow not throw exception see #696
+assert(isEvalError("Class: A not found in namespace", "class A { class B extends A {} }"));
+
+// Avoid class not found by generating it empty first #701
 class A {}
+class A { class B extends A {} }
+
+// TODO: this should be the same #698
+assertNotSame("Incorrectly, A.class is not the same as A.class", A.class, A$B.class.getSuperclass());
+
 class A {
     static A INSTANCE = new A();
 }


### PR DESCRIPTION
Remove defining class workaround/hack

Fixes #701 cannot find any reason why defining classes needs to remain
Fixes #700 class regenerate is not prevented anymore by defining classes
Added additional class generation tests exposing new issues but none related to defining classes.

Fix reload type on class changed
Fixes #699 when class is regenerated also reload the types.

Bump build version and fix warnings

