### PR TITLE
Fix methods declared after referenced

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Thu Jan 12 08:45:42 SAST 2023
-build=3703
+#Thu Jan 12 11:23:37 SAST 2023
+build=3761
 release=${project.version}

--- a/src/main/java/bsh/This.java
+++ b/src/main/java/bsh/This.java
@@ -28,8 +28,10 @@
 
 package bsh;
 
-import static bsh.ClassGenerator.ClassNodeFilter.CLASSINSTANCE;
-import static bsh.ClassGenerator.ClassNodeFilter.CLASSSTATIC;
+import static bsh.ClassGenerator.ClassNodeFilter.CLASSINSTANCEFIELDS;
+import static bsh.ClassGenerator.ClassNodeFilter.CLASSINSTANCEMETHODS;
+import static bsh.ClassGenerator.ClassNodeFilter.CLASSSTATICFIELDS;
+import static bsh.ClassGenerator.ClassNodeFilter.CLASSSTATICMETHODS;
 import static bsh.ClassGeneratorUtil.DEFAULTCONSTRUCTOR;
 import static bsh.This.Keys.BSHCONSTRUCTORS;
 import static bsh.This.Keys.BSHINIT;
@@ -760,8 +762,9 @@ public final class This implements java.io.Serializable, Runnable
             }
 
             // evaluate the instance portion of the block in it
-            try { // Evaluate the initializer block
-                instanceInitBlock.evalBlock(new CallStack(instanceNameSpace), instanceThis.declaringInterpreter, true/*override*/, CLASSINSTANCE);
+            try { // Evaluate the initializer block methods first
+                instanceInitBlock.evalBlock(new CallStack(instanceNameSpace), instanceThis.declaringInterpreter, true/*override*/, CLASSINSTANCEMETHODS);
+                instanceInitBlock.evalBlock(new CallStack(instanceNameSpace), instanceThis.declaringInterpreter, true/*override*/, CLASSINSTANCEFIELDS);
             } catch (Exception e) {
                 throw new InterpreterError("Error in class instance This initialization: " + e, e);
             }
@@ -790,8 +793,9 @@ public final class This implements java.io.Serializable, Runnable
             BSHBlock block = (BSHBlock) classStaticNameSpace.getVariable(BSHINIT.toString());
             CallStack callstack = new CallStack(classStaticNameSpace);
 
-            // evaluate the static portion of the block in the static space
-            block.evalBlock(callstack, interpreter, true/*override*/, CLASSSTATIC);
+            // evaluate the static portion of the block in the static space methods first
+            block.evalBlock(callstack, interpreter, true/*override*/, CLASSSTATICMETHODS);
+            block.evalBlock(callstack, interpreter, true/*override*/, CLASSSTATICFIELDS);
 
             // Validate that static final variables were set
             for (Variable var : Reflect.getVariables(classStaticNameSpace))

--- a/src/test/resources/test-scripts/class17.bsh
+++ b/src/test/resources/test-scripts/class17.bsh
@@ -1,0 +1,50 @@
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+/*
+    This test case looks at method references declared after referenced in fields. #359
+*/
+
+class MyStatic {
+    static int g = get();
+    static String f;
+    static {
+        f = fetch();
+    }
+    static int get() {
+        return 22;
+    }
+    static String fetch() {
+        return "22";
+    }
+}
+
+assertEquals("Integer g is 22", 22, MyStatic.g);
+assertNotNull("String f is set through static block and should not be null", MyStatic.f);
+assertEquals("String f is '22'", "22", MyStatic.f);
+assertEquals("String fetch is '22'", "22", MyStatic.fetch());
+assertEquals("Integer get is 22", 22, MyStatic.get());
+
+class MyInstance {
+    int g = get();
+    String f;
+    MyInstance() {
+        f = fetch();
+    }
+    int get() {
+        return 22;
+    }
+    String fetch() {
+        return "22";
+    }
+}
+
+myInstance = new MyInstance();
+assertEquals("Integer g is 22", 22, myInstance.g);
+assertNotNull("String f is set through constructor and should not be null", myInstance.f);
+assertEquals("String f is '22'", "22", myInstance.f);
+assertEquals("String fetch is '22'", "22", myInstance.fetch());
+assertEquals("Integer get is 22", 22, myInstance.get());
+
+complete();
+


### PR DESCRIPTION
Fixes #359 Evaluate methods first so that they can be referenced by fields declared before the methods