### PR TITLE
Fix illegal name for anonymous class in block

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Thu Jan 12 11:23:37 SAST 2023
-build=3761
+#Thu Jan 12 15:33:28 SAST 2023
+build=3792
 release=${project.version}

--- a/src/main/java/bsh/BSHAllocationExpression.java
+++ b/src/main/java/bsh/BSHAllocationExpression.java
@@ -187,7 +187,7 @@ class BSHAllocationExpression extends SimpleNode
         throws EvalError
     {
         String anon = "anon" + (++innerClassCount);
-        String name = callstack.top().getName() + "$" + anon;
+        String name = callstack.top().getName().replace('/', '_') + "$" + anon;
         This.CONTEXT_ARGS.get().put(anon, args);
         Modifiers modifiers = new Modifiers(Modifiers.CLASS);
         Class<?> clas = ClassGenerator.getClassGenerator().generateClass(

--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -729,7 +729,7 @@ class Types {
      * @param className the class name to modify
      * @return the name before $ of a class */
     public static String getBaseName(String className) {
-        int i = className.indexOf("$");
+        int i = className.lastIndexOf("$");
         if (i == -1)
             return className;
 

--- a/src/test/java/InnerClass.java
+++ b/src/test/java/InnerClass.java
@@ -8,7 +8,19 @@ public class InnerClass {
         public Inner() { }
 
         public static class Inner2 {
+            public int z = 7;
             public Inner2() { }
+        }
+    }
+
+    public class NonStaticInner {
+        public int x = 5;
+
+        public NonStaticInner() { }
+
+        public class NonStaticInner2 {
+            public int z = 7;
+            public NonStaticInner2() { }
         }
     }
 

--- a/src/test/resources/test-scripts/anonymous_sub_classes.bsh
+++ b/src/test/resources/test-scripts/anonymous_sub_classes.bsh
@@ -104,6 +104,10 @@ assertThat(sub.go(), equalTo("foo bar sub"));
 assertThat(sub.cls, equalTo(SubOverloadSuper.class));
 assertThat(sub.spr, equalTo(NoDefaultConstructor.class));
 
+// anonymous class in blocks #334
+testAn = null;
+{{{{ testAn = new Object() {}; }}}}
+assertThat("IllegalName global/... changed to global_...", testAn.getClass().getName(), startsWith("global_"));
 
 complete();
 

--- a/src/test/resources/test-scripts/innerclass.bsh
+++ b/src/test/resources/test-scripts/innerclass.bsh
@@ -1,15 +1,35 @@
 #!/bin/java bsh.Interpreter
 
 source("TestHarness.bsh");
+source("Assert.bsh");
 
-assert( java.awt.geom.Rectangle2D.Float.class instanceof Class );
+assertThat(java.awt.geom.Rectangle2D.Float.class, instanceOf(Class.class));
 
-assert( InnerClass.Inner.y == 6 );
-assert( new InnerClass.Inner() instanceof Object );
-assert( new InnerClass.Inner().x == 5 );
+// static inner class
+assertEquals(6, InnerClass.Inner.y);
+inner = new InnerClass.Inner();
+assertThat(inner, instanceOf(Object.class));
+assertThat(inner, instanceOf(InnerClass.Inner.class));
+assertEquals(5, inner.x);
 
-assert( InnerClass.Inner.Inner2.class instanceof Class );
-assert( new InnerClass.Inner.Inner2() instanceof Object );
+inner2 = new InnerClass.Inner.Inner2();
+assertThat(InnerClass.Inner.Inner2.class, instanceOf(Class.class));
+assertThat(inner2, instanceOf(Object.class));
+assertThat(inner2, instanceOf(InnerClass.Inner.Inner2.class));
+assertEquals(7, inner2.z);
+
+// non static inner class
+innerClass = new InnerClass();
+assertThat(InnerClass.NonStaticInner.class, instanceOf(Class.class));
+nonStaticInner = innerClass.new NonStaticInner();
+assertThat(nonStaticInner , instanceOf(Object.class));
+assertThat(nonStaticInner , instanceOf(InnerClass.NonStaticInner.class));
+assertEquals(5, nonStaticInner.x);
+
+nonStaticInner2 = nonStaticInner.new NonStaticInner2();
+assertThat(InnerClass.NonStaticInner.NonStaticInner2.class, instanceOf(Class.class));
+assertThat(nonStaticInner2, instanceOf(Object.class));
+assertThat(nonStaticInner2, instanceOf(InnerClass.NonStaticInner.NonStaticInner2.class));
+assertEquals(7, nonStaticInner2.z);
 
 complete();
-

--- a/src/test/resources/test-scripts/innerclass2.bsh
+++ b/src/test/resources/test-scripts/innerclass2.bsh
@@ -1,12 +1,44 @@
 #!/bin/java bsh.Interpreter
 
 source("TestHarness.bsh");
-
+source("Assert.bsh");
 // import inner class
 import InnerClass.Inner;
 
-assert( Inner instanceof bsh.ClassIdentifier );
-assert( new Inner() instanceof Object );
+assert(Inner instanceof bsh.ClassIdentifier);
+assert(new Inner() instanceof Object);
+
+// name space variables accessible as fields
+public class AA {
+    public AA() {}
+    i = 6;
+    public int inst = 3;
+    public static String stat = "hello BeanShell";
+
+    public class BB {
+        BB() {}
+        BB(boolean b) { isInner = b; }
+        public boolean isInner = true;
+    }
+}
+
+assertEquals("hello BeanShell", AA.stat);
+AA.stat = "foo";
+assertEquals("foo", AA.stat);
+
+aa = new AA();
+assertEquals(6, aa.i);
+assertEquals(3, aa.inst);
+
+aa.i = 66;
+aa.inst = 33;
+
+assertEquals(66, aa.i);
+assertEquals(33, aa.inst);
+
+assertTrue(aa.new BB().isInner);
+assertTrue(new AA.BB().isInner);
+assertFalse(new AA.BB(false).isInner);
+assertFalse(aa.new BB(false).isInner);
 
 complete();
-

--- a/src/test/resources/test-scripts/innerclass3.bsh
+++ b/src/test/resources/test-scripts/innerclass3.bsh
@@ -1,0 +1,50 @@
+#!/bin/java bsh.Interpreter
+
+source("TestHarness.bsh");
+source("Assert.bsh");
+
+// extend static inner class
+class StaticInnerChild extends InnerClass.Inner {}
+
+assertEquals(6, StaticInnerChild.y);
+inner = new StaticInnerChild();
+assertThat(inner, instanceOf(Object.class));
+assertThat(inner, instanceOf(InnerClass.Inner.class));
+assertThat(inner, instanceOf(StaticInnerChild.class));
+assertEquals(5, inner.x);
+
+class StaticInnerChild2 extends InnerClass.Inner.Inner2 {}
+
+inner2 = new StaticInnerChild2();
+assertThat(inner2, instanceOf(Object.class));
+assertThat(inner2, instanceOf(InnerClass.Inner.Inner2.class));
+assertThat(inner2, instanceOf(StaticInnerChild2.class));
+assertEquals(7, inner2.z);
+
+// extend non static inner class
+class NonStaticInnerChild extends InnerClass.NonStaticInner {
+    NonStaticInnerChild(InnerClass in) {
+        super(in);
+    }
+}
+
+innerClass = new InnerClass();
+nonStaticInner = new NonStaticInnerChild(innerClass);
+assertThat(nonStaticInner , instanceOf(Object.class));
+assertThat(nonStaticInner , instanceOf(InnerClass.NonStaticInner.class));
+assertThat(nonStaticInner , instanceOf(NonStaticInnerChild.class));
+assertEquals(5, nonStaticInner.x);
+
+class NonStaticInnerChild2 extends InnerClass.NonStaticInner.NonStaticInner2 {
+    NonStaticInnerChild2(InnerClass.NonStaticInner in) {
+        super(in);
+    }
+}
+
+nonStaticInner2 = new NonStaticInnerChild2(nonStaticInner);
+assertThat(nonStaticInner2, instanceOf(Object.class));
+assertThat(nonStaticInner2, instanceOf(InnerClass.NonStaticInner.NonStaticInner2.class));
+assertThat(nonStaticInner2, instanceOf(NonStaticInnerChild2.class));
+assertEquals(7, nonStaticInner2.z);
+
+complete();


### PR DESCRIPTION
Fixes #334 anonymous classes use the block name space for a named prefix which has / in the name, fix replaces / with _

Additional inner class tests
Added tests for constructing non static JAVA compiled inner classes
Added tests for extending static and non-statice JAVA compiled inner classes