### PR TITLE
Block name space cache fix

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Thu Jan 12 15:33:28 SAST 2023
-build=3792
+#Fri Jan 13 08:11:40 SAST 2023
+build=3927
 release=${project.version}

--- a/src/main/java/bsh/BlockNameSpace.java
+++ b/src/main/java/bsh/BlockNameSpace.java
@@ -68,13 +68,6 @@ class BlockNameSpace extends NameSpace
             this.id = id;
         }
 
-        /** Compares the calculated hash code with object for equality.
-         *  {@inheritDoc} */
-        @Override
-        public boolean equals(final Object obj) {
-            return null != obj && hashCode() == obj.hashCode();
-        }
-
         /** Return a calculated hash code from name space and block id.
          * {@inheritDoc} */
         @Override
@@ -83,7 +76,7 @@ class BlockNameSpace extends NameSpace
 
     /** Weak reference cache for reusable block namespaces */
     private static final ReferenceCache<UniqueBlock,NameSpace> blockspaces
-        = new ReferenceCache<UniqueBlock, NameSpace>(Type.Soft, Type.Soft, 4000) {
+        = new ReferenceCache<UniqueBlock, NameSpace>(Type.Weak, Type.Weak, 100) {
             /** Create block namespace based on unique block key as required */
             protected NameSpace create(UniqueBlock key) {
                 return new BlockNameSpace(key.ns, key.id);
@@ -164,38 +157,6 @@ class BlockNameSpace extends NameSpace
         } catch ( UtilEvalError e ) { return false; }
     }
 
-/**
-        Get the actual BlockNameSpace 'this' reference.
-        <p/>
-        Normally a 'this' reference to a BlockNameSpace (e.g. if () { } )
-        resolves to the parent namespace (e.g. the namespace containing the
-        "if" statement).  However when code inside the BlockNameSpace needs to
-        resolve things relative to 'this' we must use the actual block's 'this'
-        reference.  Name.java is smart enough to handle this using
-        getBlockThis().
-        @see #getThis( Interpreter )
-    This getBlockThis( Interpreter declaringInterpreter )
-    {
-        return super.getThis( declaringInterpreter );
-    }
-*/
-
-    //
-    // Begin methods which simply delegate to our parent (enclosing scope)
-    //
-
-    /**
-        This method recurses to find the nearest non-BlockNameSpace parent.
-
-    public NameSpace getParent()
-    {
-        NameSpace parent = super.getParent();
-        if ( parent instanceof BlockNameSpace )
-            return parent.getParent();
-        else
-            return parent;
-    }
-*/
     /** do we need this? */
     private NameSpace getNonBlockParent()
     {

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -94,7 +94,7 @@ import java.util.ResourceBundle;
     See the BeanShell User's Manual for more information.
 */
 public class Interpreter
-    implements Runnable, Serializable
+    implements Runnable, Serializable, BshClassManager.Listener
 {
     /* --- Begin static members --- */
 
@@ -202,9 +202,9 @@ public class Interpreter
             BshClassManager bcm = BshClassManager.createClassManager( this );
             namespace = new NameSpace(namespace, bcm, "global");
         }
-
         this.setConsole(console);
         this.setNameSpace(namespace);
+        this.getClassManager().addListener(this);
 
         if ( Interpreter.DEBUG.get() )
             Interpreter.debug("Time to initialize interpreter: interactive=",
@@ -760,9 +760,10 @@ public class Interpreter
      * for subsequent calls. Only use this if completely done with current
      * interpreter and desperate to clear as much resources as possible. */
     public void reset() {
-        getClassManager().reset();
-        globalNameSpace.clear();
+        this.getClassManager().reset();
+        this.globalNameSpace.clear();
         Name.clearParts();
+        Reflect.instanceCache.clear();
     }
 
     /**
@@ -1379,6 +1380,12 @@ public class Interpreter
             this.err = err;
         }
 
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void classLoaderChanged() {
+        Reflect.instanceCache.clear();
     }
 
 }

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -1221,7 +1221,7 @@ public final class Reflect {
         }
     }
 
-    private static final Map<Class<?>,Object> instanceCache = new WeakHashMap<>();
+    static final Map<Class<?>,Object> instanceCache = new WeakHashMap<>();
 
     /*
      * Class new instance or null, wrap exception handling and

--- a/src/test/resources/test-scripts/forenhanced.bsh
+++ b/src/test/resources/test-scripts/forenhanced.bsh
@@ -229,5 +229,16 @@ funk() {
 funk();
 assert(count == 0);
 
+// test interrupt loop
+repetition=0;
+for (i:2) {
+  repetition++;
+  Thread.currentThread().interrupt();
+}
+assert(1 == repetition);
+
+// no statement for coverage
+for (i:2);
+for (int i:2);
 
 complete();

--- a/src/test/resources/test-scripts/forscope.bsh
+++ b/src/test/resources/test-scripts/forscope.bsh
@@ -37,4 +37,12 @@ assert(
         "for (int foo=1, int bar=2; foo < 3; foo++ ) { int bar = 3; }" )
 );
 
+// test interrupt loop
+repetition=0;
+for (i=0; i<=2; i++) {
+  repetition++;
+  Thread.currentThread().interrupt();
+}
+assert(1 == repetition);
+
 complete();

--- a/src/test/resources/test-scripts/iterator.bsh
+++ b/src/test/resources/test-scripts/iterator.bsh
@@ -41,4 +41,10 @@ while ( javait.hasNext() )
 }
 assert( flag() == 10 );
 
+// test interrupt loop
+repetition=0;
+while (repetition++ <= 2)
+  Thread.currentThread().interrupt();
+assert(1 == repetition);
+
 complete();


### PR DESCRIPTION
As per discussions on #659 made block name space cache optional and only implemented it for the loops, for, for enhanced, and while.
Refactored and simplified loop node implementations which was overly complex due to the use of a switch statement to deal with control statements making break unusable.
Improved coverage on the loop nodes also implementing the Thread interrupt which the loops are respecting.

Make interpreter a class loader listener.
As a singular instance to react to class loader changed events, able to clear static references.