### PR TITLE
Expect hash code collisions in reference cache

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Sat Jan 14 12:35:42 SAST 2023
-build=4159
+#Mon Jan 16 13:36:37 SAST 2023
+build=4191
 release=${project.version}

--- a/src/main/java/bsh/util/ReferenceCache.java
+++ b/src/main/java/bsh/util/ReferenceCache.java
@@ -202,7 +202,7 @@ public abstract class ReferenceCache<K,V> {
         /** Create a new cache key and capture its hash code.
          * @param key to provide equality for */
         public CacheKey(T key) {
-            hashCode = key.hashCode();
+            hashCode = key.hashCode() + key.toString().chars().sum();
         }
 
         /** Provides dereference for the key.


### PR DESCRIPTION
Fixes #680 by adding the sum of char to int of the to string of a key we may mitigate pure hash code collisions.