### PR TITLE
Reload typed variables

### DIFF
--- a/src/conf/version.properties
+++ b/src/conf/version.properties
@@ -14,6 +14,6 @@
 #
 #Project version number - populated by maven
 #Project build number - incremented by beanshell-maven-plugin
-#Mon Jan 16 13:36:37 SAST 2023
-build=4191
+#Tue Jan 17 01:30:24 SAST 2023
+build=4387
 release=${project.version}

--- a/src/main/java/bsh/BSHFormalParameters.java
+++ b/src/main/java/bsh/BSHFormalParameters.java
@@ -27,10 +27,10 @@
 
 package bsh;
 
-class BSHFormalParameters extends SimpleNode
-{
+class BSHFormalParameters extends SimpleNode implements BshClassManager.Listener {
     private String [] paramNames;
     private Modifiers [] paramModifiers;
+    private boolean listener;
     /**
         For loose type parameters the paramTypes are null.
     */
@@ -117,5 +117,24 @@ class BSHFormalParameters extends SimpleNode
 
         return paramTypes;
     }
+
+    /** Property getter for listener.
+     * @return boolean return the listener */
+    public boolean isListener() {
+        return listener;
+    }
+
+    /** Property setter for listener.
+     * @param listener the listener to set */
+    public void setListener(boolean listener) {
+        this.listener = listener;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void classLoaderChanged() {
+        paramTypes = null;
+    }
+
 }
 

--- a/src/main/java/bsh/BSHPrimitiveType.java
+++ b/src/main/java/bsh/BSHPrimitiveType.java
@@ -30,10 +30,10 @@ package bsh;
 
 class BSHPrimitiveType extends SimpleNode
 {
-    public Class type;
+    public Class<?> type;
 
     BSHPrimitiveType(int id) { super(id); }
-    public Class getType() { return type; }
+    public Class<?> getType() { return type; }
 
     @Override
     public String toString() {

--- a/src/main/java/bsh/BSHTypedVariableDeclaration.java
+++ b/src/main/java/bsh/BSHTypedVariableDeclaration.java
@@ -106,6 +106,9 @@ class BSHTypedVariableDeclaration extends SimpleNode {
                                     ((Primitive) value).numberValue());
                         namespace.setTypedVariable(
                                 dec.name, type, value, modifiers );
+                        if (!namespace.isMethod)
+                            interpreter.getClassManager().addListener(
+                                namespace.getVariableImpl(dec.name, false));
                     }
                     value = namespace.getVariable(dec.name);
                 } catch ( UtilEvalError e ) {

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -73,7 +73,6 @@ public class BshMethod implements Serializable, Cloneable, BshClassManager.Liste
 
     // Scripted method body
     protected BSHBlock methodBody;
-    private BSHMethodDeclaration methodNode;
     // Java Method, for a BshObject that delegates to a real Java method
     private Invocable javaMethod;
     private Object javaObject;
@@ -90,7 +89,6 @@ public class BshMethod implements Serializable, Cloneable, BshClassManager.Liste
             method.paramsNode.paramTypes, method.paramsNode.getParamModifiers(),
             method.blockNode, declaringNameSpace, modifiers, method.isVarArgs );
         this.isScriptedObject = isScriptedObject;
-        this.methodNode = method;
     }
 
     BshMethod(
@@ -572,10 +570,14 @@ public class BshMethod implements Serializable, Cloneable, BshClassManager.Liste
 
     /** Reload types if reload is true */
     private void reloadTypes() {
-        if (!reload) return;
-        reload = false;
-        creturnType = methodNode.reevalReturnType();
-        cparamTypes = methodNode.reevalParamTypes();
+        if (reload) try {
+            reload = false;
+            if (Reflect.isGeneratedClass(creturnType))
+                creturnType = declaringNameSpace.getClass(creturnType.getName());
+            for (int i = 0; i < cparamTypes.length; i++)
+                if (Reflect.isGeneratedClass(cparamTypes[i]))
+                    cparamTypes[i] = declaringNameSpace.getClass(cparamTypes[i].getName());
+        } catch (UtilEvalError e) { /* should not happen on reload */ }
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/bsh/Variable.java
+++ b/src/main/java/bsh/Variable.java
@@ -25,7 +25,9 @@
  *****************************************************************************/
 package bsh;
 
-public class Variable implements java.io.Serializable
+import java.io.Serializable;
+
+public class Variable implements Serializable, BshClassManager.Listener
 {
     public static final int DECLARATION=0, ASSIGNMENT=1;
     /** A null type means an untyped variable */
@@ -166,5 +168,13 @@ public class Variable implements java.io.Serializable
     public String toString() {
         return "Variable: " + StringUtil.variableString(this)
                 + ", value:" + value + ", lhs = " + lhs;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void classLoaderChanged() {
+        if (Reflect.isGeneratedClass(type)) try {
+            type = Reflect.getThisNS(type).getClass(type.getName());
+        } catch (UtilEvalError e) { /** should not happen on reload */ }
     }
 }

--- a/src/test/resources/test-scripts/classreload3.bsh
+++ b/src/test/resources/test-scripts/classreload3.bsh
@@ -54,4 +54,99 @@ a = new A();
 assertSame("Returns the same typed instance untyped parameter reloaded", a, objectA(a));
 assertNotSame("A and A before is not the same", b4, a.getClass());
 
+// assign local typed variable
+A assignTypedVar(A a) {
+    A b = a;
+    return b;
+}
+a = new A();
+b4 = a.getClass();
+assertSame("Returns the same typed instance typed local variable", a, assignTypedVar(a));
+class A {}
+a = new A();
+assertSame("Returns the same typed instance typed local variable reloaded", a, assignTypedVar(a));
+assertNotSame("A and A before is not the same", b4, a.getClass());
+
+// scripted object assign local typed variable
+A assignThisTypedVar(A a) {
+    A b = a;
+    return this.b;
+}
+a = new A();
+b4 = a.getClass();
+assertSame("Returns the same typed instance typed instance variable", a, assignThisTypedVar(a));
+class A {}
+a = new A();
+assertSame("Returns the same typed instance typed instance variable reloaded", a, assignThisTypedVar(a));
+assertNotSame("A and A before is not the same", b4, a.getClass());
+
+// scripted object return instance method
+A thisMethod(A a) {
+    A get(A b) {
+        return b;
+    }
+    return this.get(a);
+}
+a = new A();
+b4 = a.getClass();
+assertSame("Returns the same typed instance typed instance method", a, thisMethod(a));
+class A {}
+a = new A();
+assertSame("Returns the same typed instance typed instance method reloaded", a, thisMethod(a));
+assertNotSame("A and A before is not the same", b4, a.getClass());
+
+// scripted object return instance method assign local typed variable
+A thisMethodAssignLocal(A a) {
+    A getC(A b) {
+        A c = b;
+        return c;
+    }
+    return this.getC(a);
+}
+a = new A();
+b4 = a.getClass();
+assertSame("Returns the same typed instance typed instance method local variable", a, thisMethodAssignLocal(a));
+class A {}
+a = new A();
+assertSame("Returns the same typed instance typed instance method local variable reloaded", a, thisMethodAssignLocal(a));
+assertNotSame("A and A before is not the same", b4, a.getClass());
+
+{
+    // in block scripted object return instance method assign local typed variable
+    A inBlockThisMethodAssignLocal(A a) {
+        A getC(A b) {
+            A c = b;
+            return c;
+        }
+        return this.getC(a);
+    }
+    a = new A();
+    b4 = a.getClass();
+    assertSame("Returns the same typed instance typed instance method local variable", a, inBlockThisMethodAssignLocal(a));
+    eval("class A {}");
+    a = new A();
+    assertSame("Returns the same typed instance typed instance method local variable reloaded", a, inBlockThisMethodAssignLocal(a));
+    assertNotSame("A and A before is not the same", b4, a.getClass());
+}
+
+// Variable of type
+A a = new A();
+b4 = a.getClass();
+assertSame("Variable type same as class type", A.class, a.getClass());
+class A {}
+a = new A();
+assertSame("Variable type still same as class type", A.class, a.getClass());
+assertNotSame("A and A before is not the same", b4, a.getClass());
+
+{
+    // Variable of type in block
+    A b = new A();
+    b4 = b.getClass();
+    assertSame("Variable type in block same as class type", A.class, b.getClass());
+    eval("class A {}");
+    b = new A();
+    assertSame("Variable type in block still same as class type", A.class, b.getClass());
+    assertNotSame("A and A before is not the same", b4, b.getClass());
+}
+
 complete();


### PR DESCRIPTION
Fixes #709 local variables listens to class loader changed events 
Improvement to the #707 and #708 fixes made before by reloading type from namespace instead of reevaluating the declared method nodes.