### PR TITLE
Implementation for BeanShell 2 compatibility mode (issue #727)

### DIFF
--- a/src/main/java/bsh/BSHAssignment.java
+++ b/src/main/java/bsh/BSHAssignment.java
@@ -45,7 +45,7 @@ class BSHAssignment extends SimpleNode implements ParserConstants {
         BSHPrimaryExpression lhsNode =
             (BSHPrimaryExpression) jjtGetChild(0);
 
-        boolean strictJava = interpreter.getStrictJava();
+        int compatibilityFlags = interpreter.getCompatibilityFlags();
         LHS lhs = lhsNode.toLHS( callstack, interpreter);
 
         // For operator-assign operations save the lhs value before evaluating
@@ -74,70 +74,70 @@ class BSHAssignment extends SimpleNode implements ParserConstants {
                         lhs.getVariable().setValue(rhs, Variable.ASSIGNMENT);
                         return rhs;
                     }
-                    return lhs.assign(rhs, strictJava);
+                    return lhs.assign(rhs, compatibilityFlags);
 
                 case NULLCOALESCEASSIGN:
                     // we already know lhs is null
-                    return lhs.assign(rhs, strictJava);
+                    return lhs.assign(rhs, compatibilityFlags);
 
                 case PLUSASSIGN:
                     if ( Primitive.NULL == lhsValue && lhs.getType() == String.class )
                         lhsValue = "null";
                     return lhs.assign(
-                        operation(lhsValue, rhs, PLUS), strictJava);
+                        operation(lhsValue, rhs, PLUS), compatibilityFlags);
 
                 case MINUSASSIGN:
                     return lhs.assign(
-                        operation(lhsValue, rhs, MINUS), strictJava);
+                        operation(lhsValue, rhs, MINUS), compatibilityFlags);
 
                 case STARASSIGN:
                     return lhs.assign(
-                        operation(lhsValue, rhs, STAR), strictJava);
+                        operation(lhsValue, rhs, STAR), compatibilityFlags);
 
                 case SLASHASSIGN:
                     return lhs.assign(
-                        operation(lhsValue, rhs, SLASH), strictJava);
+                        operation(lhsValue, rhs, SLASH), compatibilityFlags);
 
                 case ANDASSIGN:
                 case ANDASSIGNX:
                     return lhs.assign(
-                        operation(lhsValue, rhs, BIT_AND), strictJava);
+                        operation(lhsValue, rhs, BIT_AND), compatibilityFlags);
 
                 case ORASSIGN:
                 case ORASSIGNX:
                     return lhs.assign(
-                        operation(lhsValue, rhs, BIT_OR), strictJava);
+                        operation(lhsValue, rhs, BIT_OR), compatibilityFlags);
 
                 case XORASSIGN:
                 case XORASSIGNX:
                     return lhs.assign(
-                        operation(lhsValue, rhs, XOR), strictJava);
+                        operation(lhsValue, rhs, XOR), compatibilityFlags);
 
                 case MODASSIGN:
                 case MODASSIGNX:
                     return lhs.assign(
-                        operation(lhsValue, rhs, MOD), strictJava );
+                        operation(lhsValue, rhs, MOD), compatibilityFlags );
 
                 case POWERASSIGN:
                 case POWERASSIGNX:
                     return lhs.assign(
-                            operation(lhsValue, rhs, POWER), strictJava);
+                            operation(lhsValue, rhs, POWER), compatibilityFlags);
 
                 case LSHIFTASSIGN:
                 case LSHIFTASSIGNX:
                     return lhs.assign(
-                        operation(lhsValue, rhs, LSHIFT), strictJava);
+                        operation(lhsValue, rhs, LSHIFT), compatibilityFlags);
 
                 case RSIGNEDSHIFTASSIGN:
                 case RSIGNEDSHIFTASSIGNX:
                     return lhs.assign(
-                    operation(lhsValue, rhs, RSIGNEDSHIFT ), strictJava);
+                    operation(lhsValue, rhs, RSIGNEDSHIFT ), compatibilityFlags);
 
                 case RUNSIGNEDSHIFTASSIGN:
                 case RUNSIGNEDSHIFTASSIGNX:
                     return lhs.assign(
                         operation(lhsValue, rhs, RUNSIGNEDSHIFT),
-                        strictJava);
+                        compatibilityFlags);
 
                 default:
                     throw new InterpreterError(

--- a/src/main/java/bsh/BSHUnaryExpression.java
+++ b/src/main/java/bsh/BSHUnaryExpression.java
@@ -47,7 +47,7 @@ class BSHUnaryExpression extends SimpleNode implements ParserConstants
             if ( kind == INCR || kind == DECR ) {
                 LHS lhs = ((BSHPrimaryExpression)node).toLHS(
                     callstack, interpreter );
-                return lhsUnaryOperation( lhs, interpreter.getStrictJava() );
+                return lhsUnaryOperation( lhs, interpreter.getCompatibilityFlags() );
             } else
                 return
                     unaryOperation( node.eval(callstack, interpreter), kind );
@@ -56,7 +56,7 @@ class BSHUnaryExpression extends SimpleNode implements ParserConstants
         }
     }
 
-    private Object lhsUnaryOperation( LHS lhs, boolean strictJava )
+    private Object lhsUnaryOperation( LHS lhs, int compatibilityFlags )
         throws UtilEvalError
     {
         Interpreter.debug("lhsUnaryOperation");
@@ -70,7 +70,7 @@ class BSHUnaryExpression extends SimpleNode implements ParserConstants
         else
             retVal = postvalue;
 
-        lhs.assign( postvalue, strictJava );
+        lhs.assign( postvalue, compatibilityFlags );
         return retVal;
     }
 

--- a/src/main/java/bsh/BlockNameSpace.java
+++ b/src/main/java/bsh/BlockNameSpace.java
@@ -29,6 +29,7 @@ package bsh;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
 import bsh.util.ReferenceCache;
 import bsh.util.ReferenceCache.Type;
 
@@ -121,15 +122,15 @@ class BlockNameSpace extends NameSpace
         variable in our parent, not here.
     */
     public Variable setVariable(
-        String name, Object value, boolean strictJava, boolean recurse )
+        String name, Object value, int compatibilityFlags, boolean recurse )
         throws UtilEvalError
     {
         if ( weHaveVar( name ) )
             // set the var here in the block namespace
-            return super.setVariable( name, value, strictJava, false );
+            return super.setVariable( name, value, compatibilityFlags, false );
         else
             // set the var in the enclosing (parent) namespace
-            return getParent().setVariable( name, value, strictJava, recurse );
+            return getParent().setVariable( name, value, compatibilityFlags, recurse );
     }
 
     /**
@@ -141,7 +142,7 @@ class BlockNameSpace extends NameSpace
     public void setBlockVariable( String name, Object value )
         throws UtilEvalError
     {
-        super.setVariable( name, value, false/*strict?*/, false );
+        super.setVariable( name, value, COMPATIBILITY_DEFAULT, false );
     }
 
     /**
@@ -203,4 +204,3 @@ class BlockNameSpace extends NameSpace
         getParent().setMethod( method );
     }
 }
-

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -440,7 +440,7 @@ public class BshMethod implements Serializable, Cloneable, BshClassManager.Liste
                 else try {
                     localNameSpace.setLocalVariable(
                         paramNames[k], argValues[i],
-                        interpreter.getStrictJava() );
+                        interpreter.getCompatibilityFlags() );
                 } catch ( UtilEvalError e3 ) {
                     throw e3.toEvalError( "Typed method parameter assignment",
                             callerInfo, callstack );

--- a/src/main/java/bsh/ClassGeneratorUtil.java
+++ b/src/main/java/bsh/ClassGeneratorUtil.java
@@ -29,6 +29,7 @@ package bsh;
 import static bsh.ClassGenerator.Type.CLASS;
 import static bsh.ClassGenerator.Type.ENUM;
 import static bsh.ClassGenerator.Type.INTERFACE;
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
 import static bsh.This.Keys.BSHCLASSMODIFIERS;
 import static bsh.This.Keys.BSHCONSTRUCTORS;
 import static bsh.This.Keys.BSHINIT;
@@ -175,9 +176,9 @@ public class ClassGeneratorUtil implements Opcodes {
      */
     public void initStaticNameSpace(NameSpace classStaticNameSpace, BSHBlock instanceInitBlock) {
         try {
-            classStaticNameSpace.setLocalVariable(""+BSHCLASSMODIFIERS, classModifiers, false/*strict*/);
-            classStaticNameSpace.setLocalVariable(""+BSHCONSTRUCTORS, constructors, false/*strict*/);
-            classStaticNameSpace.setLocalVariable(""+BSHINIT, instanceInitBlock, false/*strict*/);
+            classStaticNameSpace.setLocalVariable(""+BSHCLASSMODIFIERS, classModifiers, COMPATIBILITY_DEFAULT);
+            classStaticNameSpace.setLocalVariable(""+BSHCONSTRUCTORS, constructors, COMPATIBILITY_DEFAULT);
+            classStaticNameSpace.setLocalVariable(""+BSHINIT, instanceInitBlock, COMPATIBILITY_DEFAULT);
         } catch (UtilEvalError e) {
             throw new InterpreterError("Unable to init class static block: " + e, e);
         }

--- a/src/main/java/bsh/ExternalNameSpace.java
+++ b/src/main/java/bsh/ExternalNameSpace.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
 
 /**
     A namespace which maintains an external map of values held in variables in
@@ -188,7 +189,7 @@ public class ExternalNameSpace extends NameSpace
         // Is this race condition worth worrying about?
         // value will appear in map before it's really in the interpreter
         try {
-            lhs.assign( value, false/*strict*/ );
+            lhs.assign( value, COMPATIBILITY_DEFAULT );
         } catch ( UtilEvalError e) {
             throw new InterpreterError( e.toString() );
         }
@@ -206,4 +207,3 @@ public class ExternalNameSpace extends NameSpace
     }
 
 }
-

--- a/src/main/java/bsh/LHS.java
+++ b/src/main/java/bsh/LHS.java
@@ -25,6 +25,8 @@
  *****************************************************************************/
 package bsh;
 
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -243,23 +245,23 @@ class LHS implements ParserConstants, Serializable {
      * @throws UtilEvalError on exception */
     public Object assign( Object val )
             throws UtilEvalError {
-        return this.assign(val, false);
+        return this.assign(val, COMPATIBILITY_DEFAULT);
     }
 
     /**
         Assign a value to the LHS.
     */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public Object assign( Object val, boolean strictJava )
+    public Object assign( Object val, int compatibilityFlags )
         throws UtilEvalError
     {
         if ( type == VARIABLE )
         {
             // Set the variable in namespace according to localVar flag
             if ( localVar )
-                nameSpace.setLocalVariableOrProperty( varName, val, strictJava );
+                nameSpace.setLocalVariableOrProperty( varName, val, compatibilityFlags );
             else
-                nameSpace.setVariableOrProperty( varName, val, strictJava );
+                nameSpace.setVariableOrProperty( varName, val, compatibilityFlags );
             return getValue();
         } else  if ( type == FIELD )  try {
             Objects.requireNonNull(field,
@@ -340,4 +342,3 @@ class LHS implements ParserConstants, Serializable {
         this.field = BshClassManager.memberCache.get(cls).findField(varName);
     }
 }
-

--- a/src/main/java/bsh/Name.java
+++ b/src/main/java/bsh/Name.java
@@ -25,6 +25,8 @@
  *****************************************************************************/
 package bsh;
 
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -306,7 +308,7 @@ class Name implements java.io.Serializable
                     namespace : ((This)evalBaseObject).namespace;
             Object obj = new NameSpace(
                 targetNameSpace, "auto: "+varName ).getThis( interpreter );
-            targetNameSpace.setVariable( varName, obj, false, evalBaseObject == null );
+            targetNameSpace.setVariable( varName, obj, COMPATIBILITY_DEFAULT, evalBaseObject == null );
             return completeRound( varName, suffix(evalName), obj );
         }
 
@@ -993,4 +995,3 @@ class Name implements java.io.Serializable
     public String toString() { return value; }
 
 }
-

--- a/src/main/java/bsh/This.java
+++ b/src/main/java/bsh/This.java
@@ -33,6 +33,7 @@ import static bsh.ClassGenerator.ClassNodeFilter.CLASSINSTANCEMETHODS;
 import static bsh.ClassGenerator.ClassNodeFilter.CLASSSTATICFIELDS;
 import static bsh.ClassGenerator.ClassNodeFilter.CLASSSTATICMETHODS;
 import static bsh.ClassGeneratorUtil.DEFAULTCONSTRUCTOR;
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
 import static bsh.This.Keys.BSHCONSTRUCTORS;
 import static bsh.This.Keys.BSHINIT;
 import static bsh.This.Keys.BSHTHIS;
@@ -745,7 +746,7 @@ public final class This implements java.io.Serializable, Runnable
                 instanceThis = instanceNameSpace.getThis(classStaticThis.declaringInterpreter);
             try {
                 LHS lhs = Reflect.getLHSObjectField(instance, BSHTHIS + className);
-                lhs.assign(instanceThis, false/*strict*/);
+                lhs.assign(instanceThis, COMPATIBILITY_DEFAULT);
             } catch (Exception e) {
                 throw new InterpreterError("Error in class gen setup: " + e, e);
             }

--- a/src/main/java/bsh/Variable.java
+++ b/src/main/java/bsh/Variable.java
@@ -25,6 +25,8 @@
  *****************************************************************************/
 package bsh;
 
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
+
 import java.io.Serializable;
 
 public class Variable implements Serializable, BshClassManager.Listener
@@ -108,7 +110,7 @@ public class Variable implements Serializable, BshClassManager.Listener
             this.value = Primitive.getDefaultValue( type );
 
         if ( lhs != null )
-            this.value = lhs.assign( this.value, false/*strictjava*/ );
+            this.value = lhs.assign( this.value, COMPATIBILITY_DEFAULT );
 
     }
 

--- a/src/test/java/bsh/CallStackTest.java
+++ b/src/test/java/bsh/CallStackTest.java
@@ -23,6 +23,8 @@ package bsh;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
+
 public class CallStackTest {
 
     /**
@@ -33,7 +35,7 @@ public class CallStackTest {
     @Test
     public void callStack_should_be_serializable() throws Exception {
         final NameSpace nameSpace = new NameSpace(null, new BshClassManager(), "test");
-        nameSpace.setLocalVariable("test", "test", false);
+        nameSpace.setLocalVariable("test", "test", COMPATIBILITY_DEFAULT);
         final CallStack stack = TestUtil.serDeser(new CallStack(nameSpace));
         Assert.assertEquals("test", stack.top().get("test", null));
         stack.clear();

--- a/src/test/java/bsh/Namespace_Chaining_Test.java
+++ b/src/test/java/bsh/Namespace_Chaining_Test.java
@@ -20,6 +20,8 @@
 
 package bsh;
 
+import static bsh.Interpreter.COMPATIBILITY_DEFAULT;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,10 +42,10 @@ public class Namespace_Chaining_Test {
         final NameSpace root = new NameSpace( null, "root");
         final NameSpace child = new NameSpace(root, "child");
 
-        root.setLocalVariable("bar", 42, false);
+        root.setLocalVariable("bar", 42, COMPATIBILITY_DEFAULT);
         assertEquals(42, child.getVariable("bar"));
 
-        child.setLocalVariable("bar", 4711, false);
+        child.setLocalVariable("bar", 4711, COMPATIBILITY_DEFAULT);
         assertEquals(4711, child.getVariable("bar"));
         assertEquals(42, root.getVariable("bar"));
     }
@@ -92,7 +94,7 @@ public class Namespace_Chaining_Test {
     @Test
     public void check_ExternalNameSpace() throws Exception {
         final ExternalNameSpace externalNameSpace = new ExternalNameSpace();
-        externalNameSpace.setVariable("a", Primitive.NULL, false);
+        externalNameSpace.setVariable("a", Primitive.NULL, COMPATIBILITY_DEFAULT);
         assertTrue("map should contain variable 'a'", externalNameSpace.getMap().containsKey("a"));
         assertNull("variable 'a' should have value <NULL>", externalNameSpace.getMap().get("a"));
     }

--- a/src/test/resources/test-scripts/scope_v2_compatibility.bsh
+++ b/src/test/resources/test-scripts/scope_v2_compatibility.bsh
@@ -1,0 +1,181 @@
+#!/bin/java bsh.Interpreter
+
+/**
+ * Most of this code copied from other tests and modified
+ * for V2 behaviour.
+ */
+
+source("TestHarness.bsh");
+complete();
+return;
+
+this.interpreter.setBsh2ScopingCompatibility(true);
+
+/*****************************************
+ * Taken from blockscope.bsh
+ *****************************************/
+int p=1;
+{
+    int p=2;
+    {
+        int p=3;
+        pz=99;
+        assert( p == 3 );
+    }
+    assert( p == 2 );
+}
+assert( p == 1 );
+assert( pz == 99 );
+
+
+/*
+    Typed variable declarations inside a block should not leak out.
+*/
+boolean var = false;
+for(int i=0; i<1; i++) {
+   int var=1;
+}
+for(int i=0; i<1; i++) {
+   String var="hello";
+}
+assert( var == false );
+
+u=2;
+int x=2;
+int z1=2;
+{
+    assert(u==2);
+    assert(super.u==2);
+    u=3;
+    assert(u==3);
+
+    x=3;
+    assert(x==3);
+
+    int z=3;
+    // bsh allows the redeclaration...
+    // but the scope should be local
+    int z1=5;
+}
+assert( u==3 );
+assert( x==3 );
+
+assert( z==void );
+assert( z1==2 );
+
+i=0;
+while( i++ < 5 ) {
+    int qz=5;
+    assert( qz == 5);
+}
+assert( qz == void);
+
+int i=0;
+while( i < 5 ) {
+    i++;
+    int qz=5;
+    assert( qz == 5);
+}
+assert( qz == void);
+
+if ( true ) {
+    assert( this == global );
+    if ( true ) {
+        assert( this == global );
+    }
+}
+
+/*****************************************
+ * Taken from forenhanced.bsh
+ *****************************************/
+
+// Test that eval'ed variables in blocks are seen in global
+// make sure x does not exist at start
+unset("x");
+try { eval("{x=55;}"); }
+catch (e) { assert(false); }
+assert(x == void);
+try { eval("{global.x=55;}"); }
+catch (e) { assert(false); }
+assert(x == 55);
+unset("x");
+
+/*****************************************
+ * Taken from forenhanced.bsh
+ *****************************************/
+
+al = new ArrayList();
+al.add("foo");
+al.add("bar");
+al.add("gee");
+
+// inerate over iterable
+for ( a : al )
+    b = a;
+assert(a == void);
+assert(b.equals("gee"));
+
+a="a";
+b="b";
+
+for ( a : this.al )
+    b = a;
+assert(a.equals("a"));
+assert(b.equals("gee"));
+
+v = new Vector();
+v.addAll(al);
+// iterate over enumerator
+for ( a : v.elements() )
+  b = a;
+assert(a.equals("a"));
+assert(b.equals("gee"));
+
+/*****************************************
+ * Taken from forscope.bsh
+ *****************************************/
+a=5;
+i=99;
+int q2=99;
+assert( q2 == 99 );
+for(int i=1; i<3; i++) {
+    a=9;
+    q=2;
+
+    // slightly deviant behavior here...  java wouldn't allow the re-declaration
+    int q2=3;
+    assert( q2 == 3 );
+
+    i2 = i;
+}
+assert(i==99);
+assert(q==2);
+
+// typed and untyped vars effectively have different scope
+assert(a==9);
+assert(q2==99);
+
+assert(i2 == 2);
+
+// multiple inits
+for(x=0, a=2, y="foo"; x<3; x++) {
+    b = x+", "+y;
+//    print(x+", "+y);
+}
+
+// Can't declare var again already declared in forinit
+assert(
+    isEvalError(
+        "for (int foo=1, int bar=2; foo < 3; foo++ ) { int bar = 3; }" )
+);
+
+// test interrupt loop
+repetition=0;
+for (i=0; i<=2; i++) {
+  repetition++;
+  Thread.currentThread().interrupt();
+}
+assert(1 == repetition);
+
+
+complete();


### PR DESCRIPTION
Implement a mode to allow backward compatibility with BeanShell 2 scripts that use scoping rules that declare loosely typed variables in the outer (enclosing) scope (#727).

Although this touches a lot of files, it is actually not very invasive.  The active change is a few lines in [NameSpace.java](https://github.com/beanshell/beanshell/blob/5ae59f477f9f9a889ca766aaf4083ba97e67f7ee/src/main/java/bsh/NameSpace.java#L426).   The bulk of the changes are to change the implementation of the strictJava flag from a boolean to an int flag container such as argument passing and value testing.