### PR TITLE
Changes related to issue #731 method lookup regression. 

### DIFF
--- a/src/main/java/bsh/BSHArrayInitializer.java
+++ b/src/main/java/bsh/BSHArrayInitializer.java
@@ -111,7 +111,7 @@ class BSHArrayInitializer extends SimpleNode {
 
         // force MapEntry to Map output
         if (dimensions < 2)
-            if ( MapEntry.class == inferType && Void.TYPE == baseType
+            if ( (MapEntry.class == inferType && Void.TYPE == baseType)
                  || MapEntry.class == baseType )
                 baseType = Map.class;
 

--- a/src/main/java/bsh/BSHArrayInitializer.java
+++ b/src/main/java/bsh/BSHArrayInitializer.java
@@ -26,6 +26,7 @@
 package bsh;
 
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.Map;
 import java.lang.reflect.Array;
@@ -251,10 +252,15 @@ class BSHArrayInitializer extends SimpleNode {
      * @throws EvalError thrown on cast exceptions */
     private Object toCollection(Object value, Class<?> type, CallStack callstack)
             throws EvalError {
+        /*
+         * Don't try to convert an array of collections into a collection
+         */
         Class valClaz = value.getClass();
+        Class valBase = Types.arrayElementType(valClaz);
         if ( Types.isCollectionType(type) &&
              !(valClaz.isArray() &&
-               type.isAssignableFrom(Types.arrayElementType(valClaz))))
+               (Map.class.isAssignableFrom(valBase) ||
+                Collection.class.isAssignableFrom(valBase))))
             try {
             return Types.castObject(value, type, Types.CAST);
         } catch ( UtilEvalError e ) {

--- a/src/main/java/bsh/BSHFormalParameter.java
+++ b/src/main/java/bsh/BSHFormalParameter.java
@@ -62,9 +62,24 @@ class BSHFormalParameter extends SimpleNode
     public Object eval( CallStack callstack, Interpreter interpreter)
         throws EvalError
     {
-        if ( jjtGetNumChildren() > 0 )
+        if ( jjtGetNumChildren() > 0 ) {
             type = ((BSHType)jjtGetChild(0)).getType( callstack, interpreter );
-        else
+            /*
+             * Check if dimensions have been recorded for this parameter.
+             * If so,
+             * - If no array dimensions on the type then add them now.
+             * - If there are already array dimensions on the type then
+             * throw an error.
+             */
+            if (dimensions > 0) {
+                if (!type.isArray())
+                    type = Array.newInstance(type, new int[dimensions]).getClass();
+                else
+                    throw new EvalError(
+                       "Array dimensions not allowed on both type and name: "
+                       + name, this, null );
+            }
+        } else
             type = UNTYPED;
 
         if (isVarArgs)
@@ -78,4 +93,3 @@ class BSHFormalParameter extends SimpleNode
         return super.toString() + ": " + name + ", final=" + isFinal + ", varargs=" + isVarArgs;
     }
 }
-

--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -555,7 +555,7 @@ class Types {
     */
     public static Object castObject( Class<?> toType, Class<?> fromType, Object fromValue,
             int operation, boolean checkOnly ) throws UtilEvalError {
-        // assignment to loose type, void type, or exactly same type
+        // assignment to void type, or exactly same type
         if ( toType == null || toType == fromType )
             return checkOnly ? VALID_CAST :
                 fromValue;

--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -556,7 +556,7 @@ class Types {
     public static Object castObject( Class<?> toType, Class<?> fromType, Object fromValue,
             int operation, boolean checkOnly ) throws UtilEvalError {
         // assignment to loose type, void type, or exactly same type
-        if ( toType == null || arrayElementType(toType) == arrayElementType(fromType) )
+        if ( toType == null || toType == fromType )
             return checkOnly ? VALID_CAST :
                 fromValue;
 

--- a/src/test/resources/test-scripts/arraydims.bsh
+++ b/src/test/resources/test-scripts/arraydims.bsh
@@ -184,4 +184,8 @@ assert(isEvalError("cannot assign number 2147483648 to type int", 'new int[21474
 assert(isEvalError("cannot assign number 2147483648 to type int", 'new int[2147483648w];'));
 assert(isEvalError("cannot assign number 2147483648.0 to type int", 'new int[2147483648.0w];'));
 
+// Cannot have array dims on both the type and the name
+assert(isEvalError("Array dimensions not allowed on both type and name",
+                   'func(String[] list[]) {Arrays.toString(list);}'));
+
 complete();

--- a/src/test/resources/test-scripts/expression_array.bsh
+++ b/src/test/resources/test-scripts/expression_array.bsh
@@ -340,7 +340,7 @@ assert(isEvalError("Error array get index: Index 3 out-of-bounds for length 2", 
 assert(isEvalError("Not an array or List type", "''[1];"));
 assert(isEvalError("Class: Unknow.ObjectType not found in namespace", "new Unknow.ObjectType[0];"));
 assert(isEvalError("Incompatible initializer. Allocation calls for a 2 dimensional array, but initializer is a 1 dimensional array", "new int[][] {};"));
-assert(isEvalError("Incompatible type: boolean in initializer of array type: boolean", "new {{false}, true};"));
+assert(isEvalError("Error in array initializer: Cannot cast primitive value to object type [Z", "new {{false}, true};"));
 assert(isEvalError("Incompatible type: Object[] in initializer of array type: Object at position: 1", "new {{{new Object()}}, new {new Object()}};"));
 assert(isEvalError('Error in array initializer: Cannot cast String with value "ab" to int', "new int {'ab'};"));
 assert(isEvalError("Void in array initializer, position 0", "new Object {void};"));

--- a/src/test/resources/test-scripts/methodselection.bsh
+++ b/src/test/resources/test-scripts/methodselection.bsh
@@ -1,6 +1,7 @@
 #!/bin/java bsh.Interpreter
 
 source("TestHarness.bsh");
+source("Assert.bsh");
 
 // test static method selection
 assert( MethodSelection.get_static( (int)5 ) == Integer.TYPE );
@@ -79,6 +80,20 @@ Object x = null;
 String str = String.valueOf(x);
 assert("null".equals(str));
 
+/*
+ * Test method selection with override of array type
+ * Related to issue #731
+ */
+method2( single ) {
+   return single;
+}
+
+method2( String[] list ) {
+   return method2( list[1] );
+}
+
+assertEquals( method2("a"), "a" );
+assertEquals( method2(new String[] {"a","b","c"}), "b" );
 
 complete();
 


### PR DESCRIPTION
 This is only a partial fix because each change uncovered another subtle issue.  Still work to be done.   I am posting this PR so that someone else who has a better idea of how this is supposed to work can at least see some of the issues that I found.

Fixing the issue for proper matching of the most specific method broke several other code paths that depended on the loose behaviour of the `Types.castObject` method.
Other issues that popped up that I also fixed included:
- array dimensions occurring after a variable name being ignored (hidden problem that had not been tested yet).
- arrays of different dimensions but same base type being incorrectly matched as being cast compatible.
- Arrays of collections being cast to collections (surfaced by the change to `Types.castObject`, wasn't a problem before)

Unfortunately as I made changes more issues started to crop up and I just ran out of time.  For example
- `new {{false}, true};` no longer compiles and executes correctly.  This looks to me like it shouldn't work anyway, because it is not a proper 2D array. 
- `entries = {{new Entry {"k"=3, "l"=5}, {6}}};` should get typed as `Object[][][]` but now is getting typed as 'MapEntry[][][]` and this fails.
I suspect that I might have been going down the wrong track with some of my changes.  Perhaps there is a simpler way to fix the original problem that does not cause so much other collateral damage.



