### PR TITLE
Add the missing console input stream delegate

### DIFF
--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -839,6 +839,7 @@ public class Interpreter
     public final void println( Object o ) { console.println(o); }
     public final void print( Object o ) { console.print(o); }
     public final void error( Object o ) { console.error(o); }
+    public void setIn( Reader in ) { console.setIn(in); }
     public void setOut( PrintStream out ) { console.setOut(out); }
     public void setErr( PrintStream err ) { console.setErr(err); }
 

--- a/src/test/resources/test-scripts/interpreter.bsh
+++ b/src/test/resources/test-scripts/interpreter.bsh
@@ -72,6 +72,7 @@ fout.close();
 Interpreter.main(new String[] {"test_interpreter.out"});
 System.setOut(sysout);
 System.setErr(syserr);
+System.setIn(sysin);
 new File("test_interpreter.out").delete();
 
 assert(isEvalError("bsh Interpreter: No stream", "new Interpreter().run();"));


### PR DESCRIPTION
The console delegate methods in Interpreter were missing a method to change the input stream.  This PR adds the missing method.