### PR TITLE
Add jdk 21 to the test matrix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
 
     name: Java ${{ matrix.java }} build
     steps:


### PR DESCRIPTION
As the title says, include jdk21 (a long term support release) to the test matrix