### PR TITLE
Avoid version resource collisions on shared classpaths

### DIFF
--- a/maven-build.xml
+++ b/maven-build.xml
@@ -85,7 +85,7 @@
     <copy todir="${maven.build.outputDir}">
       <fileset dir="${maven.build.resourceDir.0}"/>
     </copy>
-    <copy todir="${maven.build.outputDir}">
+    <copy todir="${maven.build.outputDir}/bsh">
       <fileset dir="${maven.build.resourceDir.1}">
         <include name="version.properties"/>
       </fileset>

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
       </resource>
       <resource>
         <directory>src/conf</directory>
+        <targetPath>bsh</targetPath>
         <filtering>true</filtering>
         <includes>
           <include>version.properties</include>

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -39,6 +39,7 @@ import java.io.Serializable;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 /**
@@ -114,7 +115,8 @@ public class Interpreter
     public static final String VERSION;
 
     static {
-        ResourceBundle b = ResourceBundle.getBundle("version");
+        ResourceBundle b = ResourceBundle.getBundle("bsh.version", Locale.ROOT,
+                Interpreter.class.getClassLoader());
         VERSION = b.getString("release") + "." + b.getString("build");
         staticInit();
     }

--- a/src/test/java/bsh/InterpreterVersionTest.java
+++ b/src/test/java/bsh/InterpreterVersionTest.java
@@ -1,0 +1,80 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+/****************************************************************************/
+
+package bsh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.util.ResourceBundle;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class InterpreterVersionTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void startsWithUnrelatedVersionResource() throws Exception {
+        assertVersionAndEvaluation("component.version=1.0\n");
+    }
+
+    @Test
+    public void ignoresUnrelatedReleaseAndBuildProperties() throws Exception {
+        assertVersionAndEvaluation("release=unrelated\nbuild=123\n");
+    }
+
+    private void assertVersionAndEvaluation(String properties) throws Exception {
+        File unrelatedJar = temporaryFolder.newFile("unrelated.jar");
+        try (JarOutputStream jar = new JarOutputStream(new FileOutputStream(unrelatedJar))) {
+            jar.putNextEntry(new JarEntry("version.properties"));
+            jar.write(properties.getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
+
+        URL beanShell = Interpreter.class.getProtectionDomain().getCodeSource().getLocation();
+        // Put the unrelated resource first, and prevent delegation to an
+        // Interpreter already initialized by the test runner's classloader.
+        try (URLClassLoader loader = new URLClassLoader(
+                new URL[] { unrelatedJar.toURI().toURL(), beanShell },
+                Interpreter.class.getClassLoader().getParent())) {
+            try {
+                Class<?> interpreter = Class.forName("bsh.Interpreter", true, loader);
+                assertSame(loader, interpreter.getClassLoader());
+                assertEquals(Interpreter.VERSION, interpreter.getField("VERSION").get(null));
+                Object instance = interpreter.getDeclaredConstructor().newInstance();
+                assertEquals(42, interpreter.getMethod("eval", String.class)
+                        .invoke(instance, "6 * 7;"));
+            } finally {
+                ResourceBundle.clearCache(loader);
+            }
+        }
+    }
+}


### PR DESCRIPTION
When another JAR provides a root-level `version.properties` earlier on a shared classpath, BeanShell can fail during `Interpreter` initialization with a missing `release` key, or silently report the other component's release/build values. #736 and #783 describe the same resource collision.

Package the filtered version metadata as `bsh/version.properties` and load `bsh.version` with the root locale and Interpreter's classloader. Update both Maven and Ant resource destinations while preserving the existing source metadata file and Maven filtering.

Add two regression tests that place a conflicting JAR before BeanShell in an isolated classloader. They verify Interpreter initialization, the correct version, and script evaluation for resources with missing keys and with unrelated release/build values. Both tests fail on fresh master. Both also fail with only the explicit-classloader change proposed in #783: a shared classloader still searches all its JARs.

Validation:

- JDK 8 `mvn -B -ntp clean verify`: 696 tests, 6 skipped, zero failures/errors, zero Checkstyle violations.
- Packaged-JAR startup, version, and evaluation checks passed on JDK 8, 11, 17, and 21 with both conflicting resources and both classpath orders (16 combinations).
- The packaged JAR contains filtered `bsh/version.properties` and no root-level `version.properties`.
- `git diff --check` passes.

Fixes #736.
Fixes #783.
