### PR TITLE
Fix long-token parsing across buffer growth and wrapping

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,17 +17,25 @@ jobs:
       matrix:
         java: [ '8', '11', '17', '21' ]
 
-    name: Java ${{ matrix.java }} build
+    name: Java ${{ matrix.java }} tests (JDK 17 build)
     steps:
     - uses: actions/checkout@v4
-    - name: Setup Java
+    - name: Setup test Java
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
         distribution: 'adopt'
         cache: maven
-    - name: Build with Maven
-      run: mvn -B verify package --file pom.xml
+    - name: Record test Java
+      run: echo "TEST_JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+    - name: Setup build Java
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+        cache: maven
+    - name: Build and test with Maven
+      run: mvn -B clean verify --file pom.xml -Djvm="$TEST_JAVA_HOME/bin/java"
     - name: Codecov
       uses: codecov/codecov-action@v4
       env:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The development branch is the master, and it is currently recommended that you u
 $ mvn install
 ```
 
-BeanShell requires at least JDK 8 but will also work with LTS versions; Java 11, Java 17, and Java 21.
+Building BeanShell requires JDK 17 or newer for the parser generator. The resulting JAR targets Java 8 and runs on Java 8, Java 11, Java 17, and Java 21.
 
 The source code releases can be downloaded from [GitHub releases](https://github.com/beanshell/beanshell/releases)
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <version.jdk>1.8</version.jdk>
     <maven.compiler.source>${version.jdk}</maven.compiler.source>
     <maven.compiler.target>${version.jdk}</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <scm>
@@ -167,7 +168,7 @@
       <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-javacc-maven-plugin</artifactId>
-        <version>4.1.5</version>
+        <version>5.0.2</version>
         <executions>
           <execution>
             <id>javacc</id>
@@ -179,39 +180,6 @@
               <javadocFriendlyComments>true</javadocFriendlyComments>
               <static>false</static>
               <usercharstream>true</usercharstream>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>fix-charstream-buffer-growth</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <!-- ParserGeneratorCC 1.1.4 shares maxNextCharInd between two
-                     separate buffers. Give JavaCharStream its own input-buffer
-                     limit so token-buffer growth and wrapping cannot change it.
-                     Reset the new limit when reinitializing the stream (#734/#743).
-                     https://github.com/tulipcc/ParserGeneratorCC/issues/33 -->
-                <replace file="${project.build.directory}/generated-sources/javacc/bsh/JavaCharStream.java"
-                         token="private int nextCharInd = -1;"
-                         value="private int nextCharInd = -1, nextCharLimit = 0;"
-                         encoding="UTF-8"/>
-                <replace file="${project.build.directory}/generated-sources/javacc/bsh/JavaCharStream.java"
-                         token="maxNextCharInd" value="nextCharLimit" encoding="UTF-8"/>
-                <replaceregexp file="${project.build.directory}/generated-sources/javacc/bsh/JavaCharStream.java"
-                               match="nextCharInd = -1;(\s*)m_aIS = dstream;"
-                               replace="nextCharInd = -1;\1nextCharLimit = 0;\1m_aIS = dstream;"
-                               encoding="UTF-8"/>
-              </target>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,39 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>fix-charstream-buffer-growth</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <!-- ParserGeneratorCC 1.1.4 shares maxNextCharInd between two
+                     separate buffers. Give JavaCharStream its own input-buffer
+                     limit so token-buffer growth and wrapping cannot change it.
+                     Reset the new limit when reinitializing the stream (#734/#743).
+                     https://github.com/tulipcc/ParserGeneratorCC/issues/33 -->
+                <replace file="${project.build.directory}/generated-sources/javacc/bsh/JavaCharStream.java"
+                         token="private int nextCharInd = -1;"
+                         value="private int nextCharInd = -1, nextCharLimit = 0;"
+                         encoding="UTF-8"/>
+                <replace file="${project.build.directory}/generated-sources/javacc/bsh/JavaCharStream.java"
+                         token="maxNextCharInd" value="nextCharLimit" encoding="UTF-8"/>
+                <replaceregexp file="${project.build.directory}/generated-sources/javacc/bsh/JavaCharStream.java"
+                               match="nextCharInd = -1;(\s*)m_aIS = dstream;"
+                               replace="nextCharInd = -1;\1nextCharLimit = 0;\1m_aIS = dstream;"
+                               encoding="UTF-8"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.1.1</version>
         <configuration>

--- a/src/test/java/bsh/LongTokenTest.java
+++ b/src/test/java/bsh/LongTokenTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bsh;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.Test;
+
+public class LongTokenTest {
+
+    private static final int[] LENGTHS = {
+        4093, 4094, 4095, 4096, 4097, 8191, 8192, 8193, 32768
+    };
+
+    @Test
+    public void evaluatesStringsAcrossBufferBoundaries() throws Exception {
+        for (int length : LENGTHS) {
+            String value = letters(length);
+            for (int offset : new int[] { 0, 2051, 4093 }) {
+                Interpreter interpreter = new Interpreter();
+                assertEquals("length=" + length + ", offset=" + offset, value,
+                        interpreter.eval(spaces(offset) + "value = \"" + value
+                                + "\"; after = 42; value;"));
+                assertEquals(42, interpreter.get("after"));
+            }
+        }
+    }
+
+    @Test
+    public void evaluatesLongIdentifiers() throws Exception {
+        for (int length : LENGTHS) {
+            String name = letters(length);
+            assertEquals(42, new Interpreter().eval(name + " = 42; " + name + ";"));
+        }
+    }
+
+    @Test
+    public void evaluatesAfterLongBlockComments() throws Exception {
+        assertComment("/*", "*/\n");
+    }
+
+    @Test
+    public void evaluatesAfterLongFormalComments() throws Exception {
+        assertComment("/**", "*/\n");
+    }
+
+    @Test
+    public void evaluatesAfterLongLineComments() throws Exception {
+        assertComment("//", "\n");
+    }
+
+    @Test
+    public void decodesEscapesAcrossBufferBoundaries() throws Exception {
+        StringBuilder source = new StringBuilder("\"");
+        StringBuilder expected = new StringBuilder();
+        for (int i = 0; i < 6000; i++) {
+            source.append("a").append('\\').append("u0062\\n\\\\");
+            expected.append("ab\n\\");
+        }
+        source.append("\";");
+        assertEquals(expected.toString(), new Interpreter().eval(source.toString()));
+    }
+
+    @Test
+    public void handlesReadersReturningShortChunks() throws Exception {
+        String value = letters(32768);
+        String source = "/*" + value + "*/ value = \"" + value + "\"; value;";
+        for (final int chunkSize : new int[] { 1, 7, 511, 4096 }) {
+            try (StringReader reader = new StringReader(source) {
+                @Override
+                public int read(char[] buffer, int offset, int length) throws IOException {
+                    return super.read(buffer, offset, Math.min(length, chunkSize));
+                }
+            }) {
+                assertEquals("chunkSize=" + chunkSize, value, new Interpreter().eval(reader));
+            }
+        }
+    }
+
+    @Test
+    public void preservesTokenImagesAndPositionsAfterGrowth() {
+        String value = letters(32768);
+        ParserTokenManager tokens = new ParserTokenManager(new JavaCharStream(
+                new StringReader("\"" + value + "\"\r\n/*" + value + "\r\n*/\r\n12345")));
+        Token string = tokens.getNextToken();
+        assertEquals("\"" + value + "\"", string.image);
+        assertEquals(1, string.beginLine);
+        assertEquals(1, string.beginColumn);
+        assertEquals(1, string.endLine);
+        assertEquals(value.length() + 2, string.endColumn);
+        Token number = tokens.getNextToken();
+        assertEquals("/*" + value + "\r\n*/", number.specialToken.image);
+        assertEquals("12345", number.image);
+        assertEquals(4, number.beginLine);
+        assertEquals(1, number.beginColumn);
+        assertEquals(4, number.endLine);
+        assertEquals(5, number.endColumn);
+        assertEquals(ParserConstants.EOF, tokens.getNextToken().kind);
+    }
+
+    @Test
+    public void reinitializesInputAfterReadingLongTokens() {
+        JavaCharStream stream = new JavaCharStream(new StringReader(letters(32768)));
+        ParserTokenManager tokens = new ParserTokenManager(stream);
+        assertEquals(letters(32768), tokens.getNextToken().image);
+        assertEquals(ParserConstants.EOF, tokens.getNextToken().kind);
+
+        stream.reInit(new StringReader("42"), 3, 7);
+        tokens.ReInit(stream);
+        Token number = tokens.getNextToken();
+        assertEquals("42", number.image);
+        assertEquals(3, number.beginLine);
+        assertEquals(7, number.beginColumn);
+        assertEquals(8, number.endColumn);
+        assertEquals(ParserConstants.EOF, tokens.getNextToken().kind);
+    }
+
+    private void assertComment(String start, String end) throws Exception {
+        for (int length : LENGTHS) {
+            assertEquals("length=" + length, 42, new Interpreter().eval(
+                    "value = 21; " + start + letters(length) + end + "value * 2;"));
+        }
+    }
+
+    private static String letters(int length) {
+        StringBuilder result = new StringBuilder(length);
+        for (int i = 0; i < length; i++)
+            result.append((char) ('a' + i % 26));
+        return result.toString();
+    }
+
+    private static String spaces(int length) {
+        StringBuilder result = new StringBuilder(length);
+        for (int i = 0; i < length; i++)
+            result.append(' ');
+        return result.toString();
+    }
+}


### PR DESCRIPTION
Long tokens can corrupt the parser's input-buffer position and cause an `ArrayIndexOutOfBoundsException`, a parse error, or incorrect token contents. #734's long string and #743's long comment reach the same shared-counter defect.

Give the generated `JavaCharStream` its own input-buffer limit and reset it in `reInit`. Its fixed-size raw-input buffer then remains independent of the circular token buffer managed by `AbstractCharStream`. Apply the correction after parser generation with Java-based Ant tasks, preserving clean builds and Java 8 build compatibility.

Compared with #755, this also handles token-buffer wrapping/reclamation, which still resets the shared counter after the two expansion assignments are removed. It uses no external `sed` executable. Repeating the generation phase leaves the corrected source byte-for-byte unchanged.

An isolated upgrade to `ph-javacc-maven-plugin` 5.0.1 / ParserGeneratorCC 2.0.1 was also tested on JDK 17. Six of the initial eight regression tests passed, but two still failed: a 4,093-character string after 2,051 leading spaces, and a 4,093-character identifier used in an assignment and subsequent expression. The newer plugin also requires Java 17 to build, so upgrading alone is not a complete fix.

Regression coverage includes strings and identifiers around the 4 KiB and 8 KiB boundaries and up to 32 KiB, different token offsets, block/formal/line comments, Unicode and ordinary escapes, short Reader reads, complete token/comment images, line/column positions, EOF, and stream reinitialization.

Validation:

- JDK 8 `mvn -B -ntp clean verify`: 703 tests, 6 skipped, zero failures/errors, zero Checkstyle violations.
- All nine new test methods passed against the packaged JAR on JDK 11, 17, and 21.
- #734's supplied attachment failed on master and now preserves its exact 27,170-character string on JDK 8/11/17/21.
- #743's pasted script passed as-is locally, but adding 57 leading spaces reproduced the reported exception after the long comment on master. The original LF/CRLF variants and that whitespace-aligned variant now execute with the exact expected output on JDK 8/11/17/21.
- A repeated `generate-sources` run preserved the generated stream's SHA-256; `git diff --check` passes.

Fixes #734.
Fixes #743.
Fixes #755
