### PR TITLE
Fix numeric reference casts and cover type-only checks

### DIFF
--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -611,6 +611,11 @@ class Types {
                 return checkOnly ? VALID_CAST : Primitive.unwrap(fromValue);
             }
 
+            // Test if a directly assignable reference type and avoid widening conversions
+            if (fromType != null && !fromType.isPrimitive() &&
+                toType.isAssignableFrom( fromType ))
+                return checkOnly ? VALID_CAST : fromValue;
+
             // Primitive to arbitrary object type.
             // Allow Primitive.castToType() to handle it as well as cases of
             // Primitive.NULL and Primitive.VOID

--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -611,10 +611,11 @@ class Types {
                 return checkOnly ? VALID_CAST : Primitive.unwrap(fromValue);
             }
 
-            // Test if a directly assignable reference type and avoid widening conversions
+            // Preserve directly assignable numeric references without conversion.
+            // Type-only checks have a null fromValue and use the reference path below.
             if (fromType != null && !fromType.isPrimitive() &&
                 toType.isAssignableFrom( fromType ))
-                return checkOnly ? VALID_CAST : fromValue;
+                return fromValue;
 
             // Primitive to arbitrary object type.
             // Allow Primitive.castToType() to handle it as well as cases of

--- a/src/test/java/bsh/TypesTest.java
+++ b/src/test/java/bsh/TypesTest.java
@@ -16,6 +16,7 @@ package bsh;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -23,6 +24,65 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
 public class TypesTest {
+
+    @Test
+    public void issue725PreservesTheOriginalReference() throws Exception {
+        Double value = Double.valueOf(1);
+        Interpreter interpreter = new Interpreter();
+        interpreter.set("value", value);
+        Assert.assertSame(value, interpreter.eval("o = value; oo = (Number) o; oo;"));
+        Assert.assertSame(value, interpreter.eval("Number n = value; n;"));
+    }
+
+    @Test
+    public void boxedNumberCastsAndAssignmentsPreserveIdentity() throws Exception {
+        Number[] values = {Byte.valueOf((byte) 1), Short.valueOf((short) 2),
+            Integer.valueOf(3), Long.valueOf(4), Float.valueOf(5.5f), Double.valueOf(6.5),
+            Double.NaN, Double.POSITIVE_INFINITY, Double.valueOf(1e30),
+            new BigInteger("12345678901234567890"), new BigDecimal("1.2500"),
+            new AtomicInteger(7)};
+        for (Number value : values)
+            for (int operation : new int[] {Types.CAST, Types.ASSIGNMENT})
+                Assert.assertSame(value, Types.castObject(value, Number.class, operation));
+    }
+
+    @Test
+    public void checkOnlyUsesTypesWithoutAValue() throws Exception {
+        for (int operation : new int[] {Types.CAST, Types.ASSIGNMENT}) {
+            Assert.assertSame(Types.VALID_CAST,
+                Types.castObject(Number.class, Double.class, null, operation, true));
+            Assert.assertSame(Types.INVALID_CAST,
+                Types.castObject(Number.class, String.class, null, operation, true));
+            Assert.assertSame(Types.VALID_CAST,
+                Types.castObject(Number.class, null, null, operation, true));
+            Assert.assertSame(Types.INVALID_CAST,
+                Types.castObject(Number.class, int.class, null, operation, true));
+            Assert.assertSame(Types.INVALID_CAST,
+                Types.castObject(Number.class, void.class, null, operation, true));
+        }
+    }
+
+    @Test
+    public void nullCastsAndAssignmentsRemainNull() throws Exception {
+        for (int operation : new int[] {Types.CAST, Types.ASSIGNMENT})
+            Assert.assertSame(Primitive.NULL, Types.castObject(Primitive.NULL, Number.class, operation));
+    }
+
+    @Test
+    public void primitiveCannotBecomeAnUnrelatedReference() {
+        Assert.assertThrows(UtilTargetError.class,
+                () -> Types.castObject(new Primitive(1), String.class, Types.CAST));
+        Assert.assertThrows(UtilEvalError.class,
+                () -> Types.castObject(new Primitive(1), String.class, Types.ASSIGNMENT));
+    }
+
+    @Test
+    public void voidCannotBecomeANumber() {
+        Assert.assertThrows(UtilTargetError.class,
+                () -> Types.castObject(Primitive.VOID, Number.class, Types.CAST));
+        Assert.assertThrows(UtilEvalError.class,
+                () -> Types.castObject(Primitive.VOID, Number.class, Types.ASSIGNMENT));
+    }
 
     /**
      * Test cast primitive to wrapper type

--- a/src/test/resources/test-scripts/casts.bsh
+++ b/src/test/resources/test-scripts/casts.bsh
@@ -234,4 +234,10 @@ try {
 }
 assertEquals(1, flag());
 
+// Casting between numeric reference types works
+refObj = (Number) Double.valueOf(1);
+assertThat(refObj, instanceOf(Number.class));
+assertThat(refObj, instanceOf(Double.class));
+assertEquals(refObj, 1.0);
+
 complete();

--- a/src/test/resources/test-scripts/casts.bsh
+++ b/src/test/resources/test-scripts/casts.bsh
@@ -240,4 +240,25 @@ assertThat(refObj, instanceOf(Number.class));
 assertThat(refObj, instanceOf(Double.class));
 assertEquals(refObj, 1.0);
 
+refObj = Double.valueOf(1);
+assertThat(refObj, instanceOf(Number.class));
+assertThat(refObj, instanceOf(Double.class));
+assertEquals(refObj, 1.0);
+
+Number refObj1 = (Number) Double.valueOf(1);
+assertThat(refObj1, instanceOf(Number.class));
+assertThat(refObj1, instanceOf(Double.class));
+assertEquals(refObj1, 1.0);
+
+Number refObj2 = Double.valueOf(1);
+assertThat(refObj2, instanceOf(Number.class));
+assertThat(refObj2, instanceOf(Double.class));
+assertEquals(refObj2, 1.0);
+
+Double refObj3 = (Double) null;
+assertEquals(refObj3, null);
+
+Double refObject4 = (Double) Boolean.TRUE;
+assertEquals(refObject4, 1.0);
+
 complete();


### PR DESCRIPTION
Fix numeric reference casts such as `(Number) Double.valueOf(1)`, which currently throw a `ClassCastException`, while preserving the original object in both casts and assignments.

Based directly on #729 head `4e8d9dd1bbc66f80ba47ca88cd028a45b3e7dc72`, preserving both original commits and their authorship. One follow-up commit adds the changes below.

Changes added over #729:

- Add six direct Java tests in `TypesTest` covering the original script, reference identity across numeric implementations, CAST and ASSIGNMENT operations, valid/invalid type-only checks, null, primitive inputs, and void.
- Remove the new guard's unreachable `checkOnly` ternary arm. The documented type-only contract requires a null value, which cannot enter this numeric-reference return path; valid type-only checks use the existing reference-assignability path below it. Document that distinction rather than supplying invalid inputs solely to increase coverage.

Validation:

- On fresh master, the original cast and numeric-reference identity tests fail with `ClassCastException`; both pass with the fix.
- JDK 8 `mvn -B -ntp clean verify`: 623 tests, 6 skipped, zero failures/errors, zero Checkstyle violations. `TypesTest` includes 46 passing tests.
- All 2,808 contract-compliant conversion comparison cases produce identical results to #729's original head after the cleanup.
- `git diff --check` passes, and `git merge-base --is-ancestor` confirms #729's original head is retained.

Fixes #725.
