### PR TITLE
Preserve null arrays in Java varargs calls

### DIFF
--- a/src/main/java/bsh/BSHAllocationExpression.java
+++ b/src/main/java/bsh/BSHAllocationExpression.java
@@ -77,7 +77,8 @@ class BSHAllocationExpression extends SimpleNode
     )
         throws EvalError
     {
-        Object[] args = argumentsNode.getArguments( callstack, interpreter );
+        CallArguments arguments = argumentsNode.getCallArguments(callstack, interpreter);
+        Object[] args = arguments.values;
         if ( args == null)
             throw new EvalError( "Null args in new.", this, callstack );
 
@@ -113,7 +114,7 @@ class BSHAllocationExpression extends SimpleNode
                 return constructWithClassBody(
                     type, args, body, callstack, interpreter );
         } else
-            return constructObject( type, args, callstack, interpreter );
+            return constructObject(type, arguments, callstack, interpreter);
     }
 
     Object constructFromEnclosingInstance(Object obj, CallStack callstack,
@@ -123,10 +124,9 @@ class BSHAllocationExpression extends SimpleNode
         if (jjtGetChild(0) instanceof BSHAmbiguousName)
             typeString = ((BSHAmbiguousName) jjtGetChild(0)).text;
 
-        Object[] args = null;
+        CallArguments arguments = new CallArguments(Reflect.ZERO_ARGS);
         if (jjtGetChild(1) instanceof BSHArguments)
-            args = ((BSHArguments) jjtGetChild(1)).getArguments(
-                        callstack, interpreter);
+            arguments = ((BSHArguments) jjtGetChild(1)).getCallArguments(callstack, interpreter);
 
         Class<?> type = null;
         for (Class<?> t : obj.getClass().getDeclaredClasses())
@@ -136,14 +136,14 @@ class BSHAllocationExpression extends SimpleNode
             }
 
         try {
-            return Reflect.constructObject( type, obj, args );
+            return Reflect.constructWithArguments(type, obj, arguments);
         } catch (InvocationTargetException e) {
             throw new TargetError("Object constructor", e.getCause(),
                     this, callstack, true);
         }
     }
 
-    private Object constructObject(Class<?> type, Object[] args,
+    private Object constructObject(Class<?> type, CallArguments arguments,
             CallStack callstack, Interpreter interpreter ) throws EvalError {
         final boolean isGeneratedClass = Reflect.isGeneratedClass(type);
         if (isGeneratedClass) {
@@ -151,7 +151,7 @@ class BSHAllocationExpression extends SimpleNode
         }
         Object obj;
         try {
-            obj = Reflect.constructObject( type, args );
+            obj = Reflect.constructWithArguments(type, null, arguments);
         } catch ( ReflectError e) {
             throw new EvalException(
                 "Constructor error: " + e.getMessage(), this, callstack, e);

--- a/src/main/java/bsh/BSHArguments.java
+++ b/src/main/java/bsh/BSHArguments.java
@@ -52,17 +52,26 @@ class BSHArguments extends SimpleNode
     public Object[] getArguments( CallStack callstack, Interpreter interpreter)
         throws EvalError
     {
-        // evaluate each child
+        return getCallArguments(callstack, interpreter).values;
+    }
+
+    CallArguments getCallArguments(CallStack callstack, Interpreter interpreter)
+            throws EvalError {
+        // Evaluate each child once, keeping null's declared type beside its value.
+        Class<?>[] types = new Class<?>[jjtGetNumChildren()];
         Object[] args = new Object[jjtGetNumChildren()];
         for(int i = 0; i < args.length; i++)
         {
-            args[i] = jjtGetChild(i).eval(callstack, interpreter);
+            CallArguments.Result result = new CallArguments.Result();
+            args[i] = CallArguments.eval(jjtGetChild(i), callstack, interpreter, result);
+            types[i] = args[i] == Primitive.NULL || args[i] == null
+                    ? result.type : Types.getType(args[i]);
             if ( args[i] == Primitive.VOID )
                 throw new EvalException( "Undefined argument: " +
                     jjtGetChild(i).getText(), this, callstack );
         }
 
-        return args;
+        return new CallArguments(args, types);
     }
 }
 

--- a/src/main/java/bsh/BSHMethodInvocation.java
+++ b/src/main/java/bsh/BSHMethodInvocation.java
@@ -48,6 +48,11 @@ class BSHMethodInvocation extends SimpleNode
     public Object eval( CallStack callstack, Interpreter interpreter )
         throws EvalError
     {
+        return eval(callstack, interpreter, null);
+    }
+
+    Object eval(CallStack callstack, Interpreter interpreter, CallArguments.Result result)
+            throws EvalError {
         NameSpace namespace = callstack.top();
         BSHAmbiguousName nameNode = getNameNode();
 
@@ -63,10 +68,10 @@ class BSHMethodInvocation extends SimpleNode
             return Primitive.VOID;
 
         Name name = nameNode.getName(namespace);
-        Object[] args = getArgsNode().getArguments(callstack, interpreter);
+        CallArguments args = getArgsNode().getCallArguments(callstack, interpreter);
 
         try {
-            return name.invokeMethod( interpreter, args, callstack, this);
+            return name.invokeMethod(interpreter, args, callstack, this, result);
         } catch (ReflectError e) {
             throw new EvalException(
                 "Error in method invocation: " + e.getMessage(),

--- a/src/main/java/bsh/BSHPrimaryExpression.java
+++ b/src/main/java/bsh/BSHPrimaryExpression.java
@@ -64,7 +64,12 @@ class BSHPrimaryExpression extends SimpleNode
     public Object eval( CallStack callstack, Interpreter interpreter)
         throws EvalError
     {
-        return eval( false, callstack, interpreter );
+        return eval(false, callstack, interpreter, null);
+    }
+
+    Object eval(CallStack callstack, Interpreter interpreter, CallArguments.Result result)
+            throws EvalError {
+        return eval(false, callstack, interpreter, result);
     }
 
     /**
@@ -92,6 +97,11 @@ class BSHPrimaryExpression extends SimpleNode
         CallStack callstack, Interpreter interpreter)
         throws EvalError
     {
+        return eval(toLHS, callstack, interpreter, null);
+    }
+
+    private Object eval(boolean toLHS, CallStack callstack, Interpreter interpreter,
+            CallArguments.Result result) throws EvalError {
         // We can cache array expressions evaluated during type inference
         if ( isArrayExpression && null != cached )
             return cached;
@@ -100,7 +110,7 @@ class BSHPrimaryExpression extends SimpleNode
 
         for( int i=1; i < jjtGetNumChildren(); i++ )
             obj = ((BSHPrimarySuffix) jjtGetChild(i)).doSuffix(
-                obj, toLHS, callstack, interpreter);
+                obj, toLHS, callstack, interpreter, result);
 
         /*
             If the result is a Node eval() it to an object or LHS
@@ -112,8 +122,9 @@ class BSHPrimaryExpression extends SimpleNode
                     obj = ((BSHAmbiguousName) obj).toLHS(
                         callstack, interpreter);
                 else
-                    obj = ((BSHAmbiguousName) obj).toObject(
-                        callstack, interpreter);
+                    obj = result == null
+                            ? ((BSHAmbiguousName) obj).toObject(callstack, interpreter)
+                            : CallArguments.eval((Node) obj, callstack, interpreter, result);
             else
                 // Some arbitrary kind of node
                 if ( toLHS )
@@ -121,7 +132,8 @@ class BSHPrimaryExpression extends SimpleNode
                     throw new EvalException("Can't assign to prefix.",
                         this, callstack );
                 else
-                    obj = ((Node) obj).eval(callstack, interpreter);
+                    obj = result == null ? ((Node) obj).eval(callstack, interpreter)
+                            : CallArguments.eval((Node) obj, callstack, interpreter, result);
 
         if ( isMapExpression ) {
             if ( obj == Primitive.VOID )

--- a/src/main/java/bsh/BSHPrimarySuffix.java
+++ b/src/main/java/bsh/BSHPrimarySuffix.java
@@ -65,6 +65,13 @@ class BSHPrimarySuffix extends SimpleNode
         CallStack callstack, Interpreter interpreter)
         throws EvalError
     {
+        return doSuffix(obj, toLHS, callstack, interpreter, null);
+    }
+
+    Object doSuffix(Object obj, boolean toLHS, CallStack callstack,
+            Interpreter interpreter, CallArguments.Result result) throws EvalError {
+        Class<?> receiverType = result == null ? null : result.type;
+        if (result != null) result.type = null;
         // Handle ".class" suffix operation
         // Prefix must be a BSHType
         if ( operation == CLASS )
@@ -90,27 +97,35 @@ class BSHPrimarySuffix extends SimpleNode
             that we can't just eval() - we need to direct the evaluation to
             the context sensitive type of result; namely object, class, etc.
         */
-        if ( obj instanceof Node )
-            if ( obj instanceof BSHAmbiguousName )
-                obj = ((BSHAmbiguousName)obj).toObject(callstack, interpreter);
+        if (obj instanceof Node) {
+            if (result != null) {
+                CallArguments.Result receiver = new CallArguments.Result();
+                obj = CallArguments.eval((Node) obj, callstack, interpreter, receiver);
+                receiverType = receiver.type;
+            } else if (obj instanceof BSHAmbiguousName)
+                obj = ((BSHAmbiguousName) obj).toObject(callstack, interpreter);
             else
-                obj = ((Node)obj).eval(callstack, interpreter);
-        else
-            if ( obj instanceof LHS ) try {
-                obj = ((LHS)obj).getValue();
-            } catch ( UtilEvalError e ) {
-                throw e.toEvalError( this, callstack );
-            }
+                obj = ((Node) obj).eval(callstack, interpreter);
+        } else if (obj instanceof LHS) try {
+            if (result != null) receiverType = ((LHS) obj).getType();
+            obj = ((LHS) obj).getValue();
+        } catch (UtilEvalError e) {
+            throw e.toEvalError(this, callstack);
+        }
 
         try
         {
             switch(operation)
             {
                 case INDEX:
-                    return doIndex( obj, toLHS, callstack, interpreter );
+                    Object indexed = doIndex(obj, toLHS, callstack, interpreter);
+                    if (result != null && obj.getClass().isArray())
+                        result.type = receiverType != null && receiverType.isArray()
+                                ? receiverType.getComponentType() : obj.getClass().getComponentType();
+                    return indexed;
 
                 case NAME:
-                    return doName( obj, toLHS, callstack, interpreter );
+                    return doName(obj, toLHS, callstack, interpreter, result);
 
                 case PROPERTY:
                     return doProperty( toLHS, obj, callstack, interpreter );
@@ -148,7 +163,7 @@ class BSHPrimarySuffix extends SimpleNode
     */
     private Object doName(
         Object obj, boolean toLHS,
-        CallStack callstack, Interpreter interpreter)
+        CallStack callstack, Interpreter interpreter, CallArguments.Result result)
             throws EvalError, ReflectError {
         try {
             // Safe Navigate operator ?. abort on null
@@ -178,7 +193,9 @@ class BSHPrimarySuffix extends SimpleNode
                     return new LHS(obj, field);
                 }
                 else try {
-                    return Reflect.getObjectFieldValue( obj, field );
+                    Object value = Reflect.getObjectFieldValue(obj, field);
+                    if (result != null) result.field(obj, field);
+                    return value;
                 } catch (Throwable t) {
                     try {
                         return Reflect.getObjectProperty( obj, field );
@@ -190,14 +207,15 @@ class BSHPrimarySuffix extends SimpleNode
 
             // Method invocation
             // (LHS or non LHS evaluation can both encounter method calls)
-            Object[] oa = ((BSHArguments)jjtGetChild(0)).getArguments(
-                callstack, interpreter);
+            CallArguments arguments = ((BSHArguments)jjtGetChild(0))
+                    .getCallArguments(callstack, interpreter);
+            Object[] oa = arguments.values;
 
             // Validate if can invoke this method
             Interpreter.mainSecurityGuard.canInvokeMethod(obj, field, oa);
 
             return Reflect.invokeObjectMethod(
-                obj, field, oa, interpreter, callstack, this );
+                obj, field, arguments, interpreter, callstack, this, result);
         } catch (UtilEvalError e1) {
             throw e1.toEvalError(this, callstack);
         }

--- a/src/main/java/bsh/BshMethod.java
+++ b/src/main/java/bsh/BshMethod.java
@@ -268,6 +268,13 @@ public class BshMethod implements Serializable, Cloneable, BshClassManager.Liste
             Node callerInfo, boolean overrideNameSpace )
         throws EvalError
     {
+        return invoke(new CallArguments(argValues), interpreter, callstack,
+                callerInfo, overrideNameSpace);
+    }
+
+    Object invoke(CallArguments arguments, Interpreter interpreter, CallStack callstack,
+            Node callerInfo, boolean overrideNameSpace) throws EvalError {
+        Object[] argValues = arguments.values;
         Interpreter.debug("Bsh method invoke: ", this.name, " overrideNameSpace: ", overrideNameSpace);
         if ( argValues != null )
             for (int i=0; i<argValues.length; i++)
@@ -283,7 +290,7 @@ public class BshMethod implements Serializable, Cloneable, BshClassManager.Liste
                 else
                     Interpreter.mainSecurityGuard.canInvokeMethod(javaObject, javaMethod.getName(), argValues);
 
-                return javaMethod.invoke(javaObject, argValues);
+                return javaMethod.invokeWithArguments(javaObject, arguments);
             } catch ( ReflectError e ) {
                 throw new EvalError(
                     "Error invoking Java method: "+e, callerInfo, callstack );

--- a/src/main/java/bsh/CallArguments.java
+++ b/src/main/java/bsh/CallArguments.java
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+ *                                                                           *
+ * This file is part of the BeanShell Java Scripting distribution.           *
+ * Documentation and updates may be found at http://www.beanshell.org/       *
+ * Patrick Niemeyer (pat@pat.net)                                            *
+ * Author of Learning Java, O'Reilly & Associates                            *
+ *                                                                           *
+ *****************************************************************************/
+
+
+
+package bsh;
+
+/** Values and lookup types belonging to one invocation, never to a cached node. */
+final class CallArguments {
+    final Object[] values;
+    final Class<?>[] types;
+
+    CallArguments(Object[] values) {
+        this(values == null ? Reflect.ZERO_ARGS : values,
+                Types.getTypes(values == null ? Reflect.ZERO_ARGS : values));
+    }
+
+    CallArguments(Object[] values, Class<?>[] types) {
+        this.values = values;
+        this.types = types;
+    }
+
+    /** Optional output slot for a declared type discovered during evaluation. */
+    static final class Result {
+        Class<?> type;
+
+        void variable(NameSpace namespace, String name) throws UtilEvalError {
+            Variable variable = namespace.getVariableImpl(name, true);
+            type = variable == null ? null : variable.getType();
+        }
+
+        void field(Object object, String name) throws UtilEvalError, ReflectError {
+            if (object instanceof This) {
+                variable(((This) object).getNameSpace(), name);
+                return;
+            }
+            Class<?> owner = object instanceof Class ? (Class<?>) object : object.getClass();
+            Invocable field = BshClassManager.memberCache.get(owner).findField(name);
+            type = field == null ? null : field.getReturnType();
+        }
+    }
+
+    /** Evaluate once, preserving declared types only when the resulting value is null. */
+    static Object eval(Node node, CallStack stack, Interpreter interpreter, Result result)
+            throws EvalError {
+        if (node instanceof BSHAssignment && ((BSHAssignment) node).operator == null) try {
+            return eval(node.jjtGetChild(0), stack, interpreter, result);
+        } catch (SafeNavigate aborted) {
+            result.type = null;
+            return Primitive.NULL;
+        }
+        if (node instanceof BSHPrimaryExpression)
+            return ((BSHPrimaryExpression) node).eval(stack, interpreter, result);
+        if (node instanceof BSHMethodInvocation)
+            return ((BSHMethodInvocation) node).eval(stack, interpreter, result);
+        if (node instanceof BSHAmbiguousName) try {
+            return ((BSHAmbiguousName) node).getName(stack.top())
+                    .toObject(stack, interpreter, false, result);
+        } catch (UtilEvalError e) {
+            throw e.toEvalError(node, stack);
+        }
+        Object value = node.eval(stack, interpreter);
+        if (node instanceof BSHCastExpression)
+            result.type = ((BSHType) node.jjtGetChild(0)).getType(stack, interpreter);
+        return value;
+    }
+}

--- a/src/main/java/bsh/ClassGenerator.java
+++ b/src/main/java/bsh/ClassGenerator.java
@@ -291,20 +291,26 @@ public final class ClassGenerator {
     public static Object invokeSuperclassMethodImpl(BshClassManager bcm,
             Object instance, Class<?> classStatic, String methodName, Object[] args)
                 throws UtilEvalError, ReflectError, InvocationTargetException {
+        return invokeSuperclassMethodImpl(bcm, instance, classStatic, methodName,
+                new CallArguments(args), null);
+    }
+
+    static Object invokeSuperclassMethodImpl(BshClassManager bcm, Object instance,
+            Class<?> classStatic, String methodName, CallArguments arguments,
+            CallArguments.Result result) throws UtilEvalError, ReflectError, InvocationTargetException {
         Class<?> superClass = classStatic.getSuperclass();
         Class<?> clas = instance.getClass();
         String superName = BSHSUPER + superClass.getSimpleName() + methodName;
 
         // look for the specially named super delegate method
         Invocable superMethod = Reflect.resolveJavaMethod(clas, superName,
-                Types.getTypes(args), false/*onlyStatic*/);
-        if (superMethod != null) return superMethod.invoke(instance, args);
-
-        // No super method, try to invoke regular method
-        // could be a superfluous "super." which is legal.
-        superMethod = Reflect.resolveExpectedJavaMethod(bcm, superClass, instance,
-                methodName, args, false/*onlyStatic*/);
-        return superMethod.invoke(instance, args);
+                arguments.types, false/*onlyStatic*/);
+        if (superMethod == null)
+            // A superfluous "super." is legal, so also try the regular method.
+            superMethod = Reflect.resolveExpectedJavaMethod(bcm, superClass, instance,
+                    methodName, arguments, false/*onlyStatic*/);
+        if (result != null) result.type = superMethod.getReturnType();
+        return superMethod.invokeWithArguments(instance, arguments);
     }
 
 }

--- a/src/main/java/bsh/Invocable.java
+++ b/src/main/java/bsh/Invocable.java
@@ -224,6 +224,12 @@ public abstract class Invocable implements Member {
         }
     }
 
+    /** Invoke with the lookup types retained by argument evaluation. */
+    Object invokeWithArguments(Object base, CallArguments arguments)
+            throws InvocationTargetException {
+        return invoke(base, arguments.values);
+    }
+
     /** {@inheritDoc} */
     @Override
     public String toString() { return toString; }

--- a/src/main/java/bsh/Invocable.java
+++ b/src/main/java/bsh/Invocable.java
@@ -163,6 +163,12 @@ public abstract class Invocable implements Member {
     /** Basic parameter collection with pulling inherited cascade chaining. */
     public ParameterType collectParamaters(Object base, Object[] params)
             throws Throwable {
+        return collectParamaters(base, params, isFixedArity(new CallArguments(params)));
+    }
+
+    /** Collect using the invocation mode selected from the argument types. */
+    protected ParameterType collectParamaters(Object base, Object[] params, boolean fixedArity)
+            throws Throwable {
         if (getLastParameterIndex() > params.length)
             throw new InvocationTargetException(null, "Insufficient parameters passed for method: " + getName() + Arrays.asList(getParameterTypes()));
         parameters.clear();
@@ -189,10 +195,10 @@ public abstract class Invocable implements Member {
      * @param pars parameter arguments
      * @return invocation result
      * @throws Throwable combined exceptions */
-    private synchronized Object invokeTarget(Object base, Object[] pars)
+    private synchronized Object invokeTarget(Object base, Object[] pars, boolean fixedArity)
             throws Throwable {
         Reflect.logInvokeMethod("Invoking method (entry): ", this, pars);
-        ParameterType pt = collectParamaters(base, pars);
+        ParameterType pt = collectParamaters(base, pars, fixedArity);
         List<Object> params = pt.params;
         Reflect.logInvokeMethod("Invoking method (after): ", this, params);
         if (getParameterCount() > 0) {
@@ -213,21 +219,29 @@ public abstract class Invocable implements Member {
      * @throws InvocationTargetException wrapped target exceptions */
     public synchronized Object invoke(Object base, Object... pars)
             throws InvocationTargetException {
-        if (null == pars)
-            pars = Reflect.ZERO_ARGS;
-        try {
-            return Primitive.wrap(
-                    invokeTarget(base, pars), getReturnType());
-        }
-        catch (Throwable ite) {
-            throw new InvocationTargetException(ite);
-        }
+        return invokeWithArguments(base, new CallArguments(pars));
     }
 
-    /** Invoke with the lookup types retained by argument evaluation. */
-    Object invokeWithArguments(Object base, CallArguments arguments)
+    /** The fixed-arity form accepts an array or a null assignable to that array. */
+    private boolean isFixedArity(CallArguments arguments) {
+        if (!isVarArgs()) return false;
+        int enclosing = this instanceof ConstructorInvocable && isInnerClass() && !isStatic() ? 1 : 0;
+        if (arguments.types.length == 0
+                || getParameterCount() != arguments.types.length + enclosing)
+            return false;
+        Class<?> last = arguments.types[arguments.types.length - 1];
+        return last == null || getVarArgsType().isAssignableFrom(last);
+    }
+
+    /** Invoke using call-local types, leaving the cached method handle unchanged. */
+    synchronized Object invokeWithArguments(Object base, CallArguments arguments)
             throws InvocationTargetException {
-        return invoke(base, arguments.values);
+        boolean fixedArity = isFixedArity(arguments);
+        try {
+            return Primitive.wrap(invokeTarget(base, arguments.values, fixedArity), getReturnType());
+        } catch (Throwable ite) {
+            throw new InvocationTargetException(ite);
+        }
     }
 
     /** {@inheritDoc} */
@@ -332,18 +346,16 @@ abstract class ExecutingInvocable extends Invocable {
      * as separate args.
      *  {@inheritDoc} */
     @Override
-    public ParameterType collectParamaters(Object base, Object[] params)
+    protected ParameterType collectParamaters(Object base, Object[] params, boolean fixedArity)
             throws Throwable {
-        super.collectParamaters(base, params);
+        super.collectParamaters(base, params, fixedArity);
         boolean isFixedArity = false;
         if (isVarArgs()) {
             if (getLastParameterIndex() < params.length) {
                 Object[] varargs;
-                if (getParameterCount() == params.length
-                    && params[getLastParameterIndex()].getClass().isArray()
-                    && getVarArgsComponentType().isAssignableFrom(params[getLastParameterIndex()].getClass().getComponentType())) {
+                if (fixedArity) {
                     isFixedArity = true;
-                    parameters.add(params[getLastParameterIndex()]);
+                    parameters.add(Primitive.unwrap(params[getLastParameterIndex()]));
                 } else {
                     varargs = Arrays.copyOfRange(
                             params, getLastParameterIndex(), params.length);
@@ -406,12 +418,12 @@ class ConstructorInvocable extends ExecutingInvocable {
      * Applies inner class mappings as required.
      * {@inheritDoc} */
     @Override
-    public ParameterType collectParamaters(Object base, Object[] params)
+    protected ParameterType collectParamaters(Object base, Object[] params, boolean fixedArity)
             throws Throwable {
         if (isInnerClass() && !isStatic())
             params = Stream.concat(
                     Stream.of(base), Stream.of(params)).toArray();
-        return super.collectParamaters(base, params);
+        return super.collectParamaters(base, params, fixedArity);
     }
 
 }
@@ -508,9 +520,9 @@ class MethodInvocable extends ExecutingInvocable {
     /** Pull the cascade inheritance chain for parameter collection.
      *  {@inheritDoc} */
     @Override
-    public ParameterType collectParamaters(Object base, Object[] params)
+    protected ParameterType collectParamaters(Object base, Object[] params, boolean fixedArity)
             throws Throwable {
-        ParameterType pt = super.collectParamaters(base, params);
+        ParameterType pt = super.collectParamaters(base, params, fixedArity);
         if (!isStatic())
             parameters.add(0, base);
         return new ParameterType(parameters, pt.isFixedArity);

--- a/src/main/java/bsh/Name.java
+++ b/src/main/java/bsh/Name.java
@@ -188,12 +188,17 @@ class Name implements java.io.Serializable
         CallStack callstack, Interpreter interpreter, boolean forceClass )
         throws UtilEvalError
     {
+        return toObject(callstack, interpreter, forceClass, null);
+    }
+
+    synchronized Object toObject(CallStack callstack, Interpreter interpreter,
+            boolean forceClass, CallArguments.Result result) throws UtilEvalError {
         reset();
 
         Object obj = null;
         while( evalName != null )
             obj = consumeNextObjectField(
-                callstack, interpreter, forceClass, false/*autoalloc*/  );
+                callstack, interpreter, forceClass, false/*autoalloc*/, result);
 
         if ( obj == null )
             throw new InterpreterError("null value in toObject()");
@@ -223,6 +228,13 @@ class Name implements java.io.Serializable
         boolean forceClass, boolean autoAllocateThis )
         throws UtilEvalError
     {
+        return consumeNextObjectField(callstack, interpreter, forceClass, autoAllocateThis, null);
+    }
+
+    private Object consumeNextObjectField(CallStack callstack, Interpreter interpreter,
+            boolean forceClass, boolean autoAllocateThis, CallArguments.Result result)
+            throws UtilEvalError {
+        if (result != null) result.type = null;
         /*
             Is it a simple variable name?
             Doing this first gives the correct Java precedence for vars
@@ -233,8 +245,10 @@ class Name implements java.io.Serializable
             Object obj = resolveThisFieldReference(
                 callstack, namespace, interpreter, evalName, false );
 
-            if ( obj != Primitive.VOID )
-                return completeRound( evalName, FINISHED, obj );
+            if ( obj != Primitive.VOID ) {
+                if (result != null) result.variable(namespace, evalName);
+                return completeRound(evalName, FINISHED, obj);
+            }
         }
 
         /*
@@ -259,6 +273,8 @@ class Name implements java.io.Serializable
 
             if ( obj != Primitive.VOID )
             {
+                if (result != null) result.variable(evalBaseObject instanceof This
+                        ? ((This) evalBaseObject).namespace : namespace, varName);
                 // Resolved the variable
                 return completeRound( varName, suffix(evalName), obj );
             }
@@ -389,6 +405,7 @@ class Name implements java.io.Serializable
                 Interpreter.debug("Name call to getStaticFieldValue, class: ",
                         clas, ", field:", field);
                 obj = Reflect.getStaticFieldValue(clas, field);
+                if (result != null) result.field(clas, field);
             } catch( ReflectError e ) {
                 Interpreter.debug("field reflect error: ", e);
             }
@@ -443,6 +460,7 @@ class Name implements java.io.Serializable
         // Note: could eliminate throwing the exception somehow
         try {
             Object obj = Reflect.getObjectFieldValue(evalBaseObject, field);
+            if (result != null) result.field(evalBaseObject, field);
             return completeRound( field, suffix(evalName), obj );
         } catch(ReflectError e) { /* not a field */ }
 
@@ -774,6 +792,13 @@ class Name implements java.io.Serializable
     )
         throws UtilEvalError, EvalError, ReflectError, InvocationTargetException
     {
+        return invokeMethod(interpreter, new CallArguments(args), callstack, callerInfo, null);
+    }
+
+    Object invokeMethod(Interpreter interpreter, CallArguments arguments,
+            CallStack callstack, Node callerInfo, CallArguments.Result result)
+            throws UtilEvalError, EvalError, ReflectError, InvocationTargetException {
+        Object[] args = arguments.values;
         String methodName = Name.suffix(value, 1);
         BshClassManager bcm = interpreter.getClassManager();
         NameSpace namespace = callstack.top();
@@ -786,12 +811,12 @@ class Name implements java.io.Serializable
             Interpreter.mainSecurityGuard.canInvokeStaticMethod(classOfStaticMethod, methodName, args);
 
             return Reflect.invokeStaticMethod(
-                bcm, classOfStaticMethod, methodName, args, callerInfo );
+                bcm, classOfStaticMethod, methodName, arguments, callerInfo, result);
         }
 
         if ( !Name.isCompound(value) )
             return invokeLocalMethod(
-                interpreter, args, callstack, callerInfo );
+                interpreter, arguments, callstack, callerInfo, result);
 
         // Note: if we want methods declared inside blocks to be accessible via
         // this.methodname() inside the block we could handle it here as a
@@ -815,8 +840,8 @@ class Name implements java.io.Serializable
                 // Validate if can invoke this super method
                 Interpreter.mainSecurityGuard.canInvokeSuperMethod(instance.getClass().getSuperclass(), instance, methodName, args);
 
-                return ClassGenerator.getClassGenerator()
-                    .invokeSuperclassMethod( bcm, instance, classStatic, methodName, args );
+                return ClassGenerator.invokeSuperclassMethodImpl(
+                        bcm, instance, classStatic, methodName, arguments, result);
             }
         }
 
@@ -841,8 +866,10 @@ class Name implements java.io.Serializable
                 NameSpace thisNamespace = Reflect.getThisNS(obj);
                 if ( null != thisNamespace ) {
                     BshMethod m = thisNamespace.getMethod(methodName, Types.getTypes(args), true);
-                    if ( null != m )
-                        return m.invoke(args, interpreter, callstack, callerInfo);
+                    if (null != m) {
+                        if (result != null) result.type = m.getReturnType();
+                        return m.invoke(arguments, interpreter, callstack, callerInfo, false);
+                    }
                 }
             }
 
@@ -851,7 +878,7 @@ class Name implements java.io.Serializable
 
             // found an object and it's not an undefined variable
             return Reflect.invokeObjectMethod(
-                obj, methodName, args, interpreter, callstack, callerInfo );
+                obj, methodName, arguments, interpreter, callstack, callerInfo, result);
         }
 
         // It's a class
@@ -871,7 +898,7 @@ class Name implements java.io.Serializable
         // Validate if can invoke this static method
         Interpreter.mainSecurityGuard.canInvokeStaticMethod(clas, methodName, args);
 
-        return Reflect.invokeStaticMethod( bcm, clas, methodName, args, callerInfo );
+        return Reflect.invokeStaticMethod(bcm, clas, methodName, arguments, callerInfo, result);
     }
 
     /**
@@ -882,16 +909,16 @@ class Name implements java.io.Serializable
     */
     private static final Pattern noOverride = Pattern.compile("eval|assert");
     private Object invokeLocalMethod(
-        Interpreter interpreter, Object[] args, CallStack callstack, Node callerInfo)
-        throws EvalError
-    {
+        Interpreter interpreter, CallArguments arguments, CallStack callstack,
+            Node callerInfo, CallArguments.Result result) throws EvalError {
+        Object[] args = arguments.values;
         Interpreter.debug( "invokeLocalMethod: ", value );
         if ( interpreter == null )
             throw new InterpreterError(
                 "invokeLocalMethod: interpreter = null");
 
         String methodName = value;
-        Class<?>[] argTypes = Types.getTypes( args );
+        Class<?>[] argTypes = arguments.types;
 
         try {
             Interpreter.mainSecurityGuard.canInvokeLocalMethod(methodName, args);
@@ -918,7 +945,8 @@ class Name implements java.io.Serializable
                     && !namespace.getParent().isClass
                     && !noOverride.matcher(meth.getName()).matches();
 
-            return meth.invoke( args, interpreter, callstack, callerInfo, overrideChild );
+            if (result != null) result.type = meth.getReturnType();
+            return meth.invoke(arguments, interpreter, callstack, callerInfo, overrideChild);
         }
 
         // Look for a BeanShell command

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -92,11 +92,19 @@ public final class Reflect {
             Object object, String methodName, Object[] args,
             Interpreter interpreter, CallStack callstack,
             Node callerInfo) throws EvalError {
+        return invokeObjectMethod(object, methodName, new CallArguments(args),
+                interpreter, callstack, callerInfo, null);
+    }
+
+    static Object invokeObjectMethod(Object object, String methodName, CallArguments arguments,
+            Interpreter interpreter, CallStack callstack, Node callerInfo,
+            CallArguments.Result result) throws EvalError {
+        Object[] args = arguments.values;
         // Bsh scripted object
         if (object instanceof This && !This.isExposedThisMethod(methodName))
             return ((This) object).invokeMethod(
-                    methodName, args, interpreter, callstack, callerInfo,
-                    false/* declaredOnly */);
+                    methodName, arguments, interpreter, callstack, callerInfo,
+                    false/* declaredOnly */, result);
         // Plain Java object, script engine exposed instance and find java method to invoke
         BshClassManager bcm = interpreter.getClassManager();
         // Flag primitive for overwrites, value/type exposure and recursion loop metigation.
@@ -114,10 +122,11 @@ public final class Reflect {
                     return (object == Primitive.VOID) ? ((Primitive)object).getType() : type;
             } try { // Script engine exposed instance for method lookup and invocation here
                 Invocable method = resolveExpectedJavaMethod(
-                        bcm, type, object, methodName, args, false);
+                        bcm, type, object, methodName, arguments, false);
                 NameSpace ns = getThisNS(object);
                 if (null != ns) ns.setNode(callerInfo);
-                return method.invoke(object, args); // script engine exposed instance call
+                if (result != null) result.type = method.getReturnType();
+                return method.invokeWithArguments(object, arguments); // script engine exposed instance call
             } catch (ReflectError re) { // Void has overstayed its welcome round about here
                 if (object == Primitive.VOID) throw new EvalError("Attempt to invoke method: "
                     + methodName + "() on undefined", callerInfo, callstack, re);
@@ -201,13 +210,20 @@ public final class Reflect {
             Object [] args, Node callerInfo )
                     throws ReflectError, UtilEvalError,
                            InvocationTargetException {
+        return invokeStaticMethod(bcm, clas, methodName, new CallArguments(args), callerInfo, null);
+    }
+
+    static Object invokeStaticMethod(BshClassManager bcm, Class<?> clas, String methodName,
+            CallArguments arguments, Node callerInfo, CallArguments.Result result)
+            throws ReflectError, UtilEvalError, InvocationTargetException {
         Interpreter.debug("invoke static Method");
         NameSpace ns = getThisNS(clas);
         if (null != ns)
             ns.setNode(callerInfo);
         Invocable method = resolveExpectedJavaMethod(
-            bcm, clas, null, methodName, args, true );
-        return method.invoke(null, args);
+            bcm, clas, null, methodName, arguments, true);
+        if (result != null) result.type = method.getReturnType();
+        return method.invokeWithArguments(null, arguments);
     }
 
     public static Object getStaticFieldValue(Class<?> clas, String fieldName)
@@ -381,11 +397,17 @@ public final class Reflect {
             BshClassManager bcm, Class<?> clas, Object object,
             String name, Object[] args, boolean staticOnly )
             throws ReflectError, UtilEvalError {
+        return resolveExpectedJavaMethod(bcm, clas, object, name, new CallArguments(args), staticOnly);
+    }
+
+    static Invocable resolveExpectedJavaMethod(BshClassManager bcm, Class<?> clas,
+            Object object, String name, CallArguments arguments, boolean staticOnly)
+            throws ReflectError, UtilEvalError {
         if ( object == Primitive.NULL )
             throw new UtilTargetError( new NullPointerException(
                 "Attempt to invoke method " +name+" on null value" ) );
 
-        Class<?>[] types = Types.getTypes(args);
+        Class<?>[] types = arguments.types;
         Invocable method = resolveJavaMethod( clas, name, types, staticOnly );
         if ( null != bcm && bcm.getStrictJava()
                 && method != null && method.getDeclaringClass().isInterface()
@@ -471,13 +493,19 @@ public final class Reflect {
     }
     static Object constructObject( Class<?> clas, Object object, Object[] args )
             throws ReflectError, InvocationTargetException {
+        return constructWithArguments(clas, object, new CallArguments(args));
+    }
+
+    static Object constructWithArguments(Class<?> clas, Object object, CallArguments arguments)
+            throws ReflectError, InvocationTargetException {
+        Object[] args = arguments.values;
         if ( null == clas )
             return Primitive.NULL;
         if ( clas.isInterface() )
             throw new ReflectError(
                 "Can't create instance of an interface: "+clas);
 
-        Class<?>[] types = Types.getTypes(args);
+        Class<?>[] types = arguments.types;
         if (clas.isMemberClass() && !isStatic(clas) && null != object)
             types = Stream.concat(Stream.of(object.getClass()),
                     Stream.of(types)).toArray(Class[]::new);
@@ -489,7 +517,7 @@ public final class Reflect {
             throw cantFindConstructor( clas, types );
 
         try {
-            return con.invoke( object, args );
+            return con.invokeWithArguments(object, arguments);
         } catch(InvocationTargetException  e) {
             if (e.getCause().getCause() instanceof IllegalAccessException)
                 throw new ReflectError(

--- a/src/main/java/bsh/This.java
+++ b/src/main/java/bsh/This.java
@@ -366,8 +366,14 @@ public final class This implements java.io.Serializable, Runnable
         boolean declaredOnly  )
         throws EvalError
     {
-        if (args == null)
-            args = Reflect.ZERO_ARGS;
+        return invokeMethod(methodName, new CallArguments(args), interpreter,
+                callstack, callerInfo, declaredOnly, null);
+    }
+
+    Object invokeMethod(String methodName, CallArguments arguments, Interpreter interpreter,
+            CallStack callstack, Node callerInfo, boolean declaredOnly,
+            CallArguments.Result resultType) throws EvalError {
+        Object[] args = arguments.values;
 
         if ( interpreter == null )
             interpreter = declaringInterpreter;
@@ -379,12 +385,14 @@ public final class This implements java.io.Serializable, Runnable
             callerInfo = Node.JAVACODE;
 
         // Find the bsh method
-        Class<?>[] types = Types.getTypes( args );
+        Class<?>[] types = arguments.types;
         BshMethod bshMethod = Reflect.getMethod(
             namespace, methodName, types, declaredOnly );
 
-        if ( bshMethod != null )
-            return bshMethod.invoke( args, interpreter, callstack, callerInfo );
+        if (bshMethod != null) {
+            if (resultType != null) resultType.type = bshMethod.getReturnType();
+            return bshMethod.invoke(arguments, interpreter, callstack, callerInfo, false);
+        }
 
         /*
             No scripted method of that name.

--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -363,9 +363,9 @@ class Types {
             return true;
 
         // null rhs type corresponds to type of Primitive.NULL
-        // assignable to any object type but not array
+        // assignable to any reference type, including an array.
         if (rhsType == null)
-            return !lhsType.isPrimitive() && !lhsType.isArray();
+            return !lhsType.isPrimitive();
 
         // prim numeric type can be boxed and assigned to number
         if ( lhsType == Number.class

--- a/src/test/java/bsh/NullVarargsTest.java
+++ b/src/test/java/bsh/NullVarargsTest.java
@@ -1,0 +1,148 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+/****************************************************************************/
+
+package bsh;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+/** Java reference calls for issue #778. */
+public class NullVarargsTest {
+    public static class Target {
+        public Object[] array;
+        public Object object;
+        public static Object[] staticArray;
+        public int calls;
+        public final Object[] received;
+        public Target(Object... args) { received = args; }
+        public String result() { return objects(received); }
+        public static String objects(Object... args) {
+            return args == null ? "null-array" : Arrays.toString(args);
+        }
+        public String instance(Object... args) { return objects(args); }
+        public static String prefix(String first, Object... args) { return objects(args); }
+        public static String strings(String... args) { return objects((Object[]) args); }
+        public static String ints(int... args) {
+            return args == null ? "null-array" : Arrays.toString(args);
+        }
+        public Object[] arrayResult() { calls++; return null; }
+        public Object objectResult() { calls++; return null; }
+        public Target receiver() { calls++; return this; }
+        public int index() { calls++; return 0; }
+        public static String overloaded(Object arg) { return "Object"; }
+        public static String overloaded(Object... args) { return "Object[]:" + objects(args); }
+        public static String ambiguous(String arg) { return "String"; }
+        public static String ambiguous(char[] arg) { return "char[]"; }
+        public static boolean same(Object expected, Object... args) { return expected == args; }
+    }
+
+    private void compare(Object expected, String script) throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Interpreter interpreter = new Interpreter();
+            interpreter.eval("import bsh.NullVarargsTest.Target;");
+            interpreter.setStrictJava(strict);
+            interpreter.eval("Target target = new Target(); Object[] array = null; Object object = null;");
+            assertEquals("strict=" + strict + ": " + script, expected, interpreter.eval(script));
+        }
+    }
+
+    @Test public void constructors() throws Exception {
+        compare(new Target((Object[]) null).result(), "new Target(null).result()");
+        compare(new Target((Object[]) null).result(), "new Target((Object[])null).result()");
+        compare(new Target((Object) null).result(), "new Target((Object)null).result()");
+        compare(new Target().result(), "new Target().result()");
+        compare(new Target(null, null).result(), "new Target(null, null).result()");
+    }
+
+    @Test public void methods() throws Exception {
+        compare(Target.objects((Object[]) null), "Target.objects(null)");
+        compare(Target.objects((Object[]) null), "Target.objects((Object[])null)");
+        compare(Target.objects((Object) null), "Target.objects((Object)null)");
+        compare(new Target().instance((Object[]) null), "target.instance(null)");
+        compare(Target.prefix("x", (Object[]) null), "Target.prefix(\"x\", null)");
+        compare(Target.strings((String[]) null), "Target.strings(null)");
+        compare(Target.strings((String) null), "Target.strings((String)null)");
+        compare(Target.ints((int[]) null), "Target.ints(null)");
+        compare(Target.ints((int[]) null), "Target.ints((int[])null)");
+    }
+
+    @Test public void declared_null_types() throws Exception {
+        compare("null-array", "Target.objects(array)");
+        compare("[null]", "Target.objects(object)");
+        compare("null-array", "Target.objects(((array)))");
+        compare("null-array", "Target.objects(target.array)");
+        compare("[null]", "Target.objects(target.object)");
+        compare("null-array", "Target.objects(Target.staticArray)");
+        compare("null-array", "Object[][] arrays = {null}; Target.objects(arrays[0])");
+        compare("[null]", "Object[] objects = {null}; Target.objects(objects[0])");
+    }
+
+    @Test public void return_types_and_imports() throws Exception {
+        compare("null-array", "Target.objects(target.arrayResult())");
+        compare("[null]", "Target.objects(target.objectResult())");
+        compare("null-array", "Object[] getArray() { return null; } Target.objects(getArray())");
+        compare("[null]", "Object getObject() { return null; } Target.objects(getObject())");
+        compare("null-array", "import static bsh.NullVarargsTest.Target.objects; objects(array)");
+        compare("[null]", "import static bsh.NullVarargsTest.Target.objects; objects(object)");
+        compare("null-array", "target.receiver().instance(array)");
+    }
+
+    @Test public void overloads() throws Exception {
+        compare(Target.overloaded((Object[]) null), "Target.overloaded(null)");
+        compare(Target.overloaded((Object[]) null), "Target.overloaded((Object[])null)");
+        compare(Target.overloaded((Object) null), "Target.overloaded((Object)null)");
+        compare(Target.overloaded((Object[]) null), "Target.overloaded(array)");
+        compare(Target.overloaded((Object) null), "Target.overloaded(object)");
+        compare("String", "Target.ambiguous(null)");
+    }
+
+    @Test public void evaluation_once_and_order() throws Exception {
+        compare("null-array:2", "String value = Target.objects(target.receiver().arrayResult()); value + \":\" + target.calls");
+        compare("null-array:1", "String value = Target.objects(target.receiver().array); value + \":\" + target.calls");
+        compare("null-array:1", "Object[][] values = {null}; String value = Target.objects(values[target.index()]); value + \":\" + target.calls");
+        compare("[1, null, 3]:3", "Target.objects(++target.calls, target.arrayResult(), ++target.calls) + \":\" + target.calls");
+    }
+
+    @Test public void repeated_calls_and_existing_arrays() throws Exception {
+        compare("null-array[null][][null, null]", "String call(Object[] array, Object object) { return Target.objects(array) + Target.objects(object) + Target.objects() + Target.objects(null, null); } call(array, object)");
+        compare(true, "Object[] values = {1, 2}; Target.same(values, values)");
+        compare("[null]", "Target.objects(new Object[]{null})");
+        compare("[1, 2]", "Target.objects(1, 2)");
+        compare("[]", "Target.ints()");
+        compare("Object[]:[a]", "Object value = new Object[]{\"a\"}; Target.overloaded(value)");
+    }
+
+    @Test public void direct_invocable_null_argument_list() throws Exception {
+        Invocable method = Invocable.get(Target.class.getMethod("objects", Object[].class));
+        assertEquals("[]", Primitive.unwrap(method.invoke(null, (Object[]) null)));
+        assertEquals("null-array", Primitive.unwrap(method.invoke(null, new Object[]{null})));
+        assertEquals("null-array", Primitive.unwrap(method.invoke(null, Primitive.NULL)));
+    }
+
+    @Test public void null_array_is_more_specific_than_object() {
+        Class<?>[] nullType = {null};
+        assertEquals(1, Reflect.findMostSpecificSignature(nullType,
+                new Class<?>[][] {{Object.class}, {Object[].class}}));
+        assertEquals(0, Reflect.findMostSpecificSignature(nullType,
+                new Class<?>[][] {{Object[].class}, {Object.class}}));
+    }
+}

--- a/src/test/java/bsh/NullVarargsTest.java
+++ b/src/test/java/bsh/NullVarargsTest.java
@@ -55,6 +55,26 @@ public class NullVarargsTest {
         public static boolean same(Object expected, Object... args) { return expected == args; }
     }
 
+    public static class SuperTarget extends Target {
+        public SuperTarget() { super(); }
+    }
+    public static class ArraySource {
+        public Object[] value() { return null; }
+    }
+    public static class ObjectSource {
+        public Object value() { return null; }
+    }
+    public static class Outer {
+        public class Inner extends Target {
+            public Inner(Object... args) { super(args); }
+        }
+    }
+    public static class Constructors {
+        public final String selected;
+        public Constructors(Object arg) { selected = "Object"; }
+        public Constructors(Object... args) { selected = "Object[]:" + Target.objects(args); }
+    }
+
     private void compare(Object expected, String script) throws Exception {
         for (boolean strict : new boolean[] {false, true}) {
             Interpreter interpreter = new Interpreter();
@@ -94,6 +114,9 @@ public class NullVarargsTest {
         compare("null-array", "Target.objects(Target.staticArray)");
         compare("null-array", "Object[][] arrays = {null}; Target.objects(arrays[0])");
         compare("[null]", "Object[] objects = {null}; Target.objects(objects[0])");
+        compare("[null]", "Object[] values = new Object[1][]; Target.objects(values[0])");
+        compare("[null]", "Object[] values = new Object[1][]; Target.objects(((Object[])values)[0])");
+        compare("null-array", "Object[][] values = new Object[1][]; Target.objects(values[0])");
     }
 
     @Test public void return_types_and_imports() throws Exception {
@@ -129,6 +152,34 @@ public class NullVarargsTest {
         compare("[1, 2]", "Target.objects(1, 2)");
         compare("[]", "Target.ints()");
         compare("Object[]:[a]", "Object value = new Object[]{\"a\"}; Target.overloaded(value)");
+    }
+
+    @Test public void constructor_overloads_and_inner_classes() throws Exception {
+        String imports = "import bsh.NullVarargsTest.Constructors; import bsh.NullVarargsTest.Outer; ";
+        compare(new Constructors((Object[]) null).selected, imports + "new Constructors(null).selected");
+        compare(new Constructors((Object) null).selected, imports + "new Constructors((Object)null).selected");
+        compare("null-array", imports + "Outer outer = new Outer(); outer.new Inner(array).result()");
+        compare("[null]", imports + "Outer outer = new Outer(); outer.new Inner(object).result()");
+    }
+
+    @Test public void cached_calls_with_different_return_types() throws Exception {
+        compare("null-array[null]null-array[null]", "import bsh.NullVarargsTest.ArraySource; import bsh.NullVarargsTest.ObjectSource; "
+                + "String call(Object value) { return Target.objects(value.value()); } "
+                + "call(new ArraySource()) + call(new ObjectSource()) + call(new ArraySource()) + call(new ObjectSource())");
+    }
+
+    @Test public void qualified_script_methods_and_super_calls() throws Exception {
+        compare("[null]", "Object getObject() { return null; } Target.objects(this.getObject())");
+        compare("null-array", "Object[] getArray() { return null; } Target.objects(this.getArray())");
+        compare("[null]", "import bsh.NullVarargsTest.SuperTarget; class Child extends SuperTarget { String call() { return super.instance((Object)null); } } new Child().call()");
+        compare("null-array", "import bsh.NullVarargsTest.SuperTarget; class Child extends SuperTarget { String call() { return super.instance((Object[])null); } } new Child().call()");
+    }
+
+    @Test public void safe_navigation_and_non_null_dispatch() throws Exception {
+        Interpreter interpreter = new Interpreter();
+        assertEquals("null-array", interpreter.eval("import bsh.NullVarargsTest.Target; Target target = null; Target.objects(target?.array)"));
+        compare("Object[]:[a]", "Target.overloaded((Object)new Object[]{\"a\"})");
+        compare("Object", "Target.overloaded(\"a\")");
     }
 
     @Test public void direct_invocable_null_argument_list() throws Exception {


### PR DESCRIPTION
Fixes #778.

Calling a Java varargs constructor or method with `null` currently passes a one-element array; for `int...`, it even passes `{0}`. Preserve a null array for bare null and array-typed null arguments, while `(Object) null` still becomes a single null element for `Object...`.

Carry evaluated argument values and lookup types separately through constructor and method calls. Retain declared null types from casts, variables, fields, array elements, and method results without evaluating expressions twice. Use those types to select fixed-arity invocation and pass null arrays through unchanged. Allow null arrays in overload resolution so `m(Object...)` wins over `m(Object)` for bare null.

Non-null arguments retain runtime type dispatch, and BeanShell's existing String preference for ambiguous bare-null calls is retained. Complex expressions without an available declared type keep their existing untyped-null behavior. Script-defined varargs packing and generated constructor delegation remain outside this change. Existing public invocation entry points are preserved.

Validation:

- The initial nine regression tests fail on upstream master `eee36c81` (eight failures and one error).
- Final JDK 8 `mvn -B -ntp clean verify`: 707 tests, 6 skipped, zero failures/errors and zero Checkstyle violations; includes 13 new regression tests.
- All 56 comparisons from the issue review agree with compiled Java in normal and strict Java modes.
- Coverage includes constructor overloads and inner classes, static/instance/imported/super methods, typed nulls, primitive varargs, array identity and covariant array element types, single evaluation and ordering, nested/repeated calls, safe navigation, and retained non-null dispatch.

The branch starts from current upstream master and separates regression tests, null type propagation, and the varargs/resolution fix into three commits.
