### PR TITLE
Prefer real methods over property aliases

### DIFF
--- a/src/main/java/bsh/BshClassManager.java
+++ b/src/main/java/bsh/BshClassManager.java
@@ -98,7 +98,11 @@ public class BshClassManager {
 
     /** Class member cached value instance **/
     static final class MemberCache {
-        private final Map<String,List<Invocable>> cache
+        /** Actual method and constructor names, also used to collect inherited members. */
+        private final Map<String,List<Invocable>> methods
+                            = new ConcurrentHashMap<>();
+        /** Property names are kept separate from actual member names. */
+        private final Map<String,List<Invocable>> properties
                             = new ConcurrentHashMap<>();
         private final Map<String,Invocable> fields
                             = new ConcurrentHashMap<>();
@@ -172,7 +176,7 @@ public class BshClassManager {
         private boolean cacheMember(Invocable member) {
             if (null == member) return false;
             if (!member.isGetter() && !member.isSetter())
-                return cacheMember(member.getName(), member);
+                return cacheMember(methods, member.getName(), member);
             String name = member.getName();
             String propName = name.replaceFirst("[gs]et|is", "");
             if (propName.length() == 1 // double caps are skipped
@@ -181,21 +185,25 @@ public class BshClassManager {
                 ch[0] = Character.toLowerCase(ch[0]);
                 propName = new String(ch);
             }
-            return cacheMember(name, member)
-                && cacheMember(propName, member);
+            boolean changed = cacheMember(methods, name, member);
+            return cacheMember(properties, propName, member) || changed;
         }
 
         /** Cache name associated with a list of members.
-         * @param name of member
+         * @param cache the method or property index
+         * @param name of member or property
          * @param member invocable instance
          * @return true if the cache changed */
-        private boolean cacheMember(String name, Invocable member) {
-            if (!hasMember(name))
-                return null == cache.put(name,
-                        Collections.singletonList(member));
-            else if (memberCount(name) == 1)
-                cache.put(name, new ArrayList<>(members(name)));
-            return members(name).add(member);
+        private boolean cacheMember(Map<String,List<Invocable>> cache,
+                String name, Invocable member) {
+            List<Invocable> members = cache.get(name);
+            if (members == null)
+                return null == cache.put(name, Collections.singletonList(member));
+            if (members.size() == 1) {
+                members = new ArrayList<>(members);
+                cache.put(name, members);
+            }
+            return members.add(member);
         }
 
         /** Find the most specific member for the given parameter types.
@@ -230,14 +238,34 @@ public class BshClassManager {
             return findBest(members(name), types);
         }
 
+        /** Resolve a call using real methods first, then property aliases.
+         * Keep alias fallback out of findMethod(), which is also used while
+         * collecting superclass and interface members.
+         * @param name requested method name
+         * @param types argument types
+         * @return an applicable member or null */
+        public Invocable findMethodOrProperty(String name, Class<?>[] types) {
+            List<Invocable> aliases = properties.get(name);
+            if (aliases == null)
+                return findMethod(name, types);
+            List<Invocable> named = methods.get(name);
+            // Applicability matters even for a single real method: an up(int)
+            // must not prevent up() from falling back to isUp().
+            Invocable method = named == null ? null
+                    : Reflect.findMostSpecificInvocable(types, named);
+            return method != null ? method : Reflect.findMostSpecificInvocable(types, aliases);
+        }
+
         /** Find static method for name. Used for static import.
          * @param name of static member
          * @return the most specific member or null */
         public Invocable findStaticMethod(String name) {
-            if (!hasMember(name))
-                return null;
-            return members(name).stream()
-                .filter(Invocable::isStatic).findFirst().get();
+            Invocable method = methods.getOrDefault(name, Collections.emptyList()).stream()
+                    .filter(Invocable::isStatic).findFirst().orElse(null);
+            if (method != null)
+                return method;
+            return properties.getOrDefault(name, Collections.emptyList()).stream()
+                    .filter(Invocable::isStatic).findFirst().orElse(null);
         }
 
         /** Find property read method or getter for property name.
@@ -246,8 +274,8 @@ public class BshClassManager {
          * @param name of property
          * @return the property read method or null */
         public Invocable findGetter(String propName) {
-            if (hasMember(propName))
-                for (Invocable property: members(propName))
+            if (properties.containsKey(propName))
+                for (Invocable property: properties.get(propName))
                     if (property.isGetter())
                         return property;
             return null;
@@ -259,8 +287,8 @@ public class BshClassManager {
          * @param name of property
          * @return the property write method or null */
         public Invocable findSetter(String propName) {
-            if (hasMember(propName))
-                for (Invocable property: members(propName))
+            if (properties.containsKey(propName))
+                for (Invocable property: properties.get(propName))
                     if (property.isSetter())
                         return property;
             return null;
@@ -279,7 +307,7 @@ public class BshClassManager {
          * @param name of member
          * @return list of members or null */
         public List<Invocable> members(String name) {
-            return cache.get(name);
+            return methods.get(name);
         }
 
         /** Retrieve the number of members associated with name.
@@ -293,7 +321,7 @@ public class BshClassManager {
          * @param name of member
          * @return true if members exists */
         public boolean hasMember(String name) {
-            return cache.containsKey(name);
+            return methods.containsKey(name);
         }
 
         /** Does field exist.

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -437,7 +437,7 @@ public final class Reflect {
             throw new InterpreterError("null class");
 
         Invocable method = BshClassManager.memberCache
-                .get(clas).findMethod(name, types);
+                .get(clas).findMethodOrProperty(name, types);
         Interpreter.debug("resolved java method: ", method, " on class: ", clas);
         checkFoundStaticMethod( method, staticOnly, clas );
         return method;
@@ -775,9 +775,7 @@ public final class Reflect {
             Class<?> clas, String propName ) {
         if ( Types.isPropertyType(clas) )
             return true;
-        return BshClassManager.memberCache
-                .get(clas).hasMember(propName)
-            && null != BshClassManager.memberCache
+        return null != BshClassManager.memberCache
                 .get(clas).findGetter(propName);
     }
 
@@ -785,9 +783,7 @@ public final class Reflect {
             Class<?> clas, String propName ) {
         if ( Types.isPropertyType(clas) )
             return true;
-        return BshClassManager.memberCache
-                .get(clas).hasMember(propName)
-            && null != BshClassManager.memberCache
+        return null != BshClassManager.memberCache
                 .get(clas).findSetter(propName);
     }
 

--- a/src/test/java/bsh/MethodPropertyDispatchTest.java
+++ b/src/test/java/bsh/MethodPropertyDispatchTest.java
@@ -1,0 +1,253 @@
+/*****************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one                *
+ * or more contributor license agreements.  See the NOTICE file              *
+ * distributed with this work for additional information                     *
+ * regarding copyright ownership.  The ASF licenses this file                *
+ * to you under the Apache License, Version 2.0 (the                         *
+ * "License"); you may not use this file except in compliance                *
+ * with the License.  You may obtain a copy of the License at                *
+ *                                                                           *
+ *     http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                           *
+ * Unless required by applicable law or agreed to in writing,                *
+ * software distributed under the License is distributed on an               *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY                    *
+ * KIND, either express or implied.  See the License for the                 *
+ * specific language governing permissions and limitations                   *
+ * under the License.                                                        *
+ *                                                                           *
+/****************************************************************************/
+
+package bsh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+import org.junit.Test;
+
+/** Real methods and property aliases must not compete in one overload set. */
+public class MethodPropertyDispatchTest {
+    public interface Shutter {
+        void up();
+        boolean isUp();
+        void down();
+        boolean isDown();
+    }
+
+    public static class Device implements Shutter {
+        public String trace = "";
+        public boolean isUp() { trace += "isUp;"; return true; }
+        public boolean isDown() { trace += "isDown;"; return false; }
+        public String getTitle() { trace += "getTitle;"; return "property"; }
+        public int getLevel() { return 0; }
+        public void setLevel(int value) { trace += "setLevel;"; }
+        public void up() { trace += "up;"; }
+        public void down() { trace += "down;"; }
+        public String title() { trace += "title;"; return "method"; }
+        public void level(int value) { trace += "level;"; }
+        public void value(Object value) { trace += "value;"; }
+        public void setValue(String value) { trace += "setValue;"; }
+        public boolean isEnabled() { trace += "isEnabled;"; return true; }
+        public void enabled(int value) { trace += "enabled;"; }
+        public void broken() { trace += "broken;"; throw new IllegalStateException("method failure"); }
+        public boolean isBroken() { trace += "isBroken;"; return false; }
+    }
+    public static class Inherited extends Device {}
+    public static class Override extends Device {
+        @java.lang.Override public void up() { trace += "override;"; }
+    }
+    public static class FieldDevice extends Device {
+        public String title = "field";
+    }
+    public static class Aliases {
+        public int reads, writes;
+        public boolean isUp() { reads++; return true; }
+        public void setLevel(int value) { writes += value; }
+    }
+    public static class StaticDevice {
+        public static String trace = "";
+        public static boolean isUp() { trace += "isUp;"; return true; }
+        public static void up() { trace += "up;"; }
+        public static void setLevel(int value) { trace += "setLevel;"; }
+        public static void level(int value) { trace += "level;"; }
+    }
+    public static class StaticAlias {
+        public static boolean isUp() { return true; }
+    }
+    public static class Empty {}
+
+    private Interpreter interpreter(boolean strict, Object device) throws Exception {
+        Interpreter interpreter = new Interpreter();
+        interpreter.setStrictJava(strict);
+        interpreter.getNameSpace().getThis(interpreter);
+        interpreter.set("device", device);
+        return interpreter;
+    }
+
+    @Test public void explicit_calls_invoke_real_methods() throws Exception {
+        for (boolean strict : new boolean[] {false, true})
+            for (Device device : new Device[] {new Device(), new Inherited()}) {
+                Interpreter interpreter = interpreter(strict, device);
+                assertNull(interpreter.eval("device.up(); device.down();"));
+                assertEquals("method", interpreter.eval("device.title();"));
+                interpreter.eval("device.level(7);");
+                assertEquals("up;down;title;level;", device.trace);
+            }
+    }
+
+    @Test public void properties_still_invoke_accessors() throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Device device = new Inherited();
+            Interpreter interpreter = interpreter(strict, device);
+            assertEquals(true, interpreter.eval("device.up"));
+            assertEquals(false, interpreter.eval("device{\"down\"}"));
+            assertEquals("property", interpreter.eval("device.title"));
+            interpreter.eval("device.level = 3; device{\"level\"} = 4;");
+            assertEquals("isUp;isDown;getTitle;setLevel;setLevel;", device.trace);
+        }
+    }
+
+    @Test public void real_method_wins_over_more_specific_alias() throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Device device = new Device();
+            interpreter(strict, device).eval("device.value(\"text\");");
+            assertEquals("value;", device.trace);
+        }
+    }
+
+    @Test public void alias_fallback_requires_no_applicable_real_method() throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Device device = new Device();
+            Interpreter interpreter = interpreter(strict, device);
+            assertEquals(true, interpreter.eval("device.enabled()"));
+            interpreter.eval("device.enabled(1); device.enabled(); device.enabled(2);");
+            assertEquals("isEnabled;enabled;isEnabled;enabled;", device.trace);
+            try {
+                interpreter.eval("device.level(1, 2);");
+                fail("Neither method nor accessor accepts two arguments");
+            } catch (EvalError expected) {
+                assertTrue(expected.getMessage().contains("not found"));
+            }
+        }
+    }
+
+    @Test public void alias_only_calls_are_retained() throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Aliases device = new Aliases();
+            Interpreter interpreter = interpreter(strict, device);
+            assertEquals(true, interpreter.eval("device.up()"));
+            interpreter.eval("device.level(7);");
+            assertEquals(1, device.reads);
+            assertEquals(7, device.writes);
+        }
+    }
+
+    @Test public void throwing_real_method_does_not_try_alias() throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Device device = new Device();
+            try {
+                interpreter(strict, device).eval("device.broken();");
+                fail("Expected the real method to throw");
+            } catch (TargetError expected) {
+                assertTrue(expected.getTarget() instanceof IllegalStateException);
+                assertEquals("method failure", expected.getTarget().getMessage());
+            }
+            assertEquals("broken;", device.trace);
+        }
+    }
+
+    @Test public void overrides_and_fields_keep_precedence() throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Device device = new Override();
+            interpreter(strict, device).eval("device.up();");
+            assertEquals("override;", device.trace);
+            FieldDevice field = new FieldDevice();
+            Interpreter interpreter = interpreter(strict, field);
+            assertEquals("field", interpreter.eval("device.title"));
+            assertEquals("property", interpreter.eval("device{\"title\"}"));
+            assertEquals("getTitle;", field.trace);
+        }
+    }
+
+    @Test public void static_calls_and_imports_use_real_names() throws Exception {
+        String owner = "bsh.MethodPropertyDispatchTest.StaticDevice";
+        for (boolean strict : new boolean[] {false, true})
+            for (String script : new String[] {
+                    "import " + owner + "; StaticDevice.up(); StaticDevice.level(7);",
+                    "import static " + owner + ".*; up(); level(7);",
+                    "import " + owner + "; import static StaticDevice.up; import static StaticDevice.level; up(); level(7);"}) {
+                StaticDevice.trace = "";
+                interpreter(strict, new Device()).eval(script);
+                assertEquals("up;level;", StaticDevice.trace);
+            }
+    }
+
+    @Test public void static_alias_fallback_is_retained() throws Exception {
+        String owner = "bsh.MethodPropertyDispatchTest.StaticAlias";
+        for (boolean strict : new boolean[] {false, true}) {
+            Interpreter interpreter = interpreter(strict, new Device());
+            assertEquals(true, interpreter.eval("import " + owner + "; StaticAlias.up()"));
+            assertEquals(true, interpreter.eval("import static " + owner + ".*; up()"));
+            // Named imports historically bind the accessor's actual name.
+            assertEquals(true, interpreter.eval("import static " + owner + ".up; isUp()"));
+        }
+    }
+
+    @Test public void imported_objects_keep_methods_and_properties() throws Exception {
+        for (boolean strict : new boolean[] {false, true}) {
+            Device device = new Device();
+            Interpreter interpreter = interpreter(strict, device);
+            interpreter.getNameSpace().importObject(device);
+            interpreter.eval("up(); level(7);");
+            assertEquals(true, interpreter.eval("up"));
+            // Strict mode requires an explicit accessor for an undeclared local property.
+            interpreter.eval(strict ? "setLevel(3);" : "level = 3;");
+            assertEquals("up;level;isUp;setLevel;", device.trace);
+        }
+    }
+
+    @Test public void property_presence_does_not_require_a_real_method() {
+        assertTrue(Reflect.hasObjectPropertyGetter(Aliases.class, "up"));
+        assertTrue(Reflect.hasObjectPropertySetter(Aliases.class, "level"));
+        assertFalse(Reflect.hasObjectPropertyGetter(Aliases.class, "missing"));
+        assertFalse(Reflect.hasObjectPropertySetter(Aliases.class, "missing"));
+        assertTrue(Reflect.hasObjectPropertyGetter(java.util.Map.class, "anything"));
+    }
+
+    @Test public void member_enumeration_contains_only_real_names() {
+        BshClassManager.MemberCache cache = BshClassManager.memberCache.get(Inherited.class);
+        for (String name : new String[] {"up", "down", "title", "level"})
+            for (Invocable member : cache.members(name))
+                assertEquals(name, member.getName());
+        BshClassManager.MemberCache aliases = BshClassManager.memberCache.get(Aliases.class);
+        assertFalse(aliases.hasMember("up"));
+        assertNull(aliases.findMethod("up", new Class<?>[0]));
+        assertNotNull(aliases.findGetter("up"));
+        assertEquals(1, aliases.memberCount(Aliases.class.getName()));
+        assertEquals(0, aliases.findMemberIndex(Aliases.class.getName(), new Class<?>[0]));
+    }
+
+    @Test public void insertion_order_cannot_replace_real_members() throws Exception {
+        Method add = BshClassManager.MemberCache.class.getDeclaredMethod("cacheMember", Invocable.class);
+        add.setAccessible(true);
+        for (String[] pair : new String[][] {{"up", "isUp"}, {"down", "isDown"},
+                {"title", "getTitle"}, {"level", "setLevel"}}) {
+            Class<?>[] types = pair[0].equals("level") ? new Class<?>[] {int.class} : new Class<?>[0];
+            Invocable method = Invocable.get(Device.class.getMethod(pair[0], types));
+            Invocable accessor = Invocable.get(Device.class.getMethod(pair[1], types));
+            for (boolean accessorFirst : new boolean[] {false, true}) {
+                BshClassManager.MemberCache cache = new BshClassManager.MemberCache(Empty.class);
+                add.invoke(cache, accessorFirst ? accessor : method);
+                add.invoke(cache, accessorFirst ? method : accessor);
+                assertEquals(pair[0], cache.findMethod(pair[0], types).getName());
+                assertEquals(pair[1], (accessor.isGetter()
+                        ? cache.findGetter(pair[0]) : cache.findSetter(pair[0])).getName());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #780.

When a class declares both `up()` and `isUp()`, BeanShell can invoke the getter for `up()` because actual method names and property aliases share an overload list. Reflection ordering determines which member wins, and inherited caches can lose the real method entirely. The same collision affects `getXxx` and `setXxx` accessors.

Keep actual method/constructor names and property names in separate maps within each member cache. Exact member lookup and hierarchy collection use only real names. Invocation first resolves applicable real methods, then falls back to property aliases only if none applies. Thus `up()` calls the real `up()` when available, while a class defining only `isUp()` retains its existing `up()` convenience call. A selected method throwing does not trigger fallback.

Property reads/writes retain their getter/setter lookup, and static imports prefer actual static method names. Existing property naming, accessor ordering, field precedence, and public invocation interfaces are preserved.

Validation:

- Added 13 regression tests; the final test class produces three failures against unchanged master `eee36c81`.
- JDK 8 `mvn -B -ntp clean verify`: 707 tests, 6 skipped, zero failures/errors and zero Checkstyle violations.
- All 16 original dispatch comparisons and eight controlled insertion-order checks pass; alias fallback remains available in normal and strict Java modes.
- Coverage includes inherited/interface members, overrides, method-versus-alias specificity, applicability fallback, throwing methods, static and imported calls, property syntax, field precedence, and member enumeration.

The branch starts from upstream master and separates regression tests and implementation into two commits.
