### PR TITLE
Document SecurityGuard embedding and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Please note only issues and pull requests made against the master branch will be
 
 For full documentation, see the [BeanShell wiki](https://github.com/beanshell/beanshell/wiki) and the [FAQ](https://github.com/beanshell/beanshell/wiki/FAQ) for frequently asked questions.
 
+See the [SecurityGuard guide](SecurityGuard.md) for Java embedding examples and application-defined script policies.
+
 The old documentation available at [http://beanshell.org](http://www.beanshell.org/docs.html) may also be useful.
 
 ### Summary of features

--- a/SecurityGuard.md
+++ b/SecurityGuard.md
@@ -1,0 +1,306 @@
+# SecurityGuard
+
+SecurityGuard lets an application define rules for operations performed by
+BeanShell scripts. For example, an application can reject selected constructors,
+method calls, or field reads. Implement the callbacks you need in Java and
+register your guard with `Interpreter.mainSecurityGuard`.
+
+## API version
+
+This page describes the `bsh.security` API in
+[#772](https://github.com/beanshell/beanshell/pull/772). That PR makes guard
+registration accessible to applications outside BeanShell's own package. Until
+it is merged, use a build containing that change to run these examples.
+
+The earlier API uses `bsh.SecurityGuard`, but its package-private
+`MainSecurityGuard` prevents ordinary external Java code from calling `add()` and
+`remove()`. Changing the import alone does not fix that visibility problem.
+
+## Registering a guard
+
+Each callback returns `true` to allow an operation or `false` to reject it.
+Default implementations return `true`. An operation must be allowed by every
+registered guard; one guard's approval cannot override another guard's rejection.
+
+Here is a complete Java application. Save it as `Main.java`. It allows adding
+elements to a list and reading an element, but rejects calling `List.size()`.
+
+```java
+package examples;
+
+import bsh.EvalError;
+import bsh.Interpreter;
+import bsh.security.SecurityGuard;
+import java.util.List;
+
+public class Main {
+    public static void main(String[] args) throws EvalError {
+        SecurityGuard guard = new SecurityGuard() {
+            @Override
+            public boolean canInvokeMethod(Object receiver, String name,
+                    Object[] arguments) {
+                return !(receiver instanceof List && "size".equals(name));
+            }
+        };
+
+        Interpreter.mainSecurityGuard.add(guard);
+        try {
+            Interpreter interpreter = new Interpreter();
+            interpreter.eval("list = new java.util.ArrayList();"
+                    + "list.add(\"Hello\"); list.add(\"World\");");
+            System.out.println(interpreter.eval("list.get(0);"));
+            try {
+                interpreter.eval("list.size();");
+            } catch (EvalError error) {
+                System.out.println(error.getMessage());
+            }
+        } finally {
+            Interpreter.mainSecurityGuard.remove(guard);
+        }
+    }
+}
+```
+
+Compile and run it with a BeanShell JAR containing #772 on the classpath. For
+example, on a Unix-like system, with that JAR named `bsh.jar`:
+
+```shell
+javac -cp bsh.jar -d . Main.java
+java -cp .:bsh.jar examples.Main
+```
+
+The output starts with `Hello`, followed by an error containing
+`SecurityError: Can't invoke this method: java.util.ArrayList.size()`.
+
+`mainSecurityGuard` is a static registry shared by all interpreter instances
+using the same loaded `Interpreter` class. Creating another interpreter does
+not create an independent policy. Register application-wide guards before
+starting script execution and remove them when that policy is no longer needed.
+The `finally` block above cleans up this standalone example. The current registry
+does not synchronize registration/removal; avoid changing it while scripts are
+using it. A guard shared by concurrent evaluations must also handle concurrent
+callback invocations.
+
+## Available callbacks
+
+Override any of the following methods in your `SecurityGuard` implementation.
+Argument arrays supplied to the callbacks contain unwrapped values: for example,
+an integer argument is a Java numeric wrapper and a null argument is Java `null`.
+
+| Callback | Operation checked | Information supplied |
+| --- | --- | --- |
+| `canConstruct(Class<?> type, Object[] args)` | Object construction, including anonymous implementation creation | Requested class or interface and constructor arguments |
+| `canInvokeMethod(Object receiver, String name, Object[] args)` | Instance method invocation, including `super.method()` | Receiver, method name, and arguments |
+| `canInvokeStaticMethod(Class<?> type, String name, Object[] args)` | Static method invocation | Class, method name, and arguments |
+| `canInvokeLocalMethod(String name, Object[] args)` | Local method or command invocation | Method name and arguments |
+| `canGetField(Object receiver, String name)` | Instance field read, including array `length` | Receiver and field name |
+| `canGetStaticField(Class<?> type, String name)` | Static field read | Class and field name |
+| `canExtends(Class<?> superClass)` | Class extension | Superclass |
+| `canImplements(Class<?> interfaceType)` | Interface implementation | Interface |
+
+The earlier `canInvokeSuperMethod()` callback was removed in #772. Move policies
+using that callback to `canInvokeMethod()`. The replacement callback also checks
+ordinary instance calls and does not receive the separate superclass argument.
+`MainSecurityGuard.remove()` returns `void` in this API.
+
+## Example policies
+
+Each Java block below is a separate guard implementation. Register its instance
+from the host application as shown above. Run the accompanying BeanShell code
+with that guard installed. Each script first performs a permitted operation,
+then attempts an operation the guard rejects.
+
+### Reject construction of lists
+
+```java
+import bsh.security.SecurityGuard;
+import java.util.List;
+
+class NoListConstruction implements SecurityGuard {
+    @Override
+    public boolean canConstruct(Class<?> type, Object[] args) {
+        return !List.class.isAssignableFrom(type);
+    }
+}
+```
+
+```bsh
+new java.util.HashMap();
+new java.util.ArrayList(); // Rejected: the requested type is ArrayList.
+```
+
+### Reject a static method
+
+```java
+import bsh.security.SecurityGuard;
+import java.util.Collections;
+
+class NoEmptyList implements SecurityGuard {
+    @Override
+    public boolean canInvokeStaticMethod(Class<?> type, String name,
+            Object[] args) {
+        return !(type == Collections.class && "emptyList".equals(name));
+    }
+}
+```
+
+```bsh
+java.util.Collections.emptyMap();
+java.util.Collections.emptyList(); // Rejected.
+```
+
+### Reject a command
+
+```java
+import bsh.security.SecurityGuard;
+
+class NoEvalCommand implements SecurityGuard {
+    @Override
+    public boolean canInvokeLocalMethod(String name, Object[] args) {
+        return !"eval".equals(name);
+    }
+}
+```
+
+```bsh
+Math.abs(-1);
+eval("30 * 3"); // Rejected as a local command call.
+```
+
+This rule checks the command named `eval`. Calls such as `interpreter.eval(...)`
+are instance method calls and require an instance-method policy if they are to
+be restricted as well.
+
+### Reject reading array length
+
+```java
+import bsh.security.SecurityGuard;
+
+class NoArrayLength implements SecurityGuard {
+    @Override
+    public boolean canGetField(Object receiver, String name) {
+        return !(receiver.getClass().isArray() && "length".equals(name));
+    }
+}
+```
+
+```bsh
+class Value { public int number = 82; }
+new Value().number;
+new Object[0].length; // Rejected.
+```
+
+### Reject reading a static field
+
+```java
+import bsh.security.SecurityGuard;
+import java.util.Collections;
+
+class NoEmptyMapField implements SecurityGuard {
+    @Override
+    public boolean canGetStaticField(Class<?> type, String name) {
+        return !(type == Collections.class && "EMPTY_MAP".equals(name));
+    }
+}
+```
+
+```bsh
+java.util.Collections.EMPTY_LIST;
+java.util.Collections.EMPTY_MAP; // Rejected.
+```
+
+### Reject extending a class
+
+```java
+import bsh.security.SecurityGuard;
+import java.util.HashMap;
+
+class NoHashMapExtension implements SecurityGuard {
+    @Override
+    public boolean canExtends(Class<?> superClass) {
+        return superClass != HashMap.class;
+    }
+}
+```
+
+```bsh
+class MyList extends java.util.ArrayList {}
+class MyMap extends java.util.HashMap {} // Rejected.
+```
+
+This example rejects the exact superclass `HashMap`. To include its subclasses,
+use `!HashMap.class.isAssignableFrom(superClass)` instead.
+
+### Reject implementing an interface
+
+```java
+import bsh.security.SecurityGuard;
+import java.util.List;
+
+class NoListImplementation implements SecurityGuard {
+    @Override
+    public boolean canImplements(Class<?> interfaceType) {
+        return interfaceType != List.class;
+    }
+}
+```
+
+```bsh
+class MyMap extends java.util.HashMap implements java.util.Map {}
+class MyList extends java.util.ArrayList implements java.util.List {} // Rejected.
+```
+
+The callback checks explicitly declared interfaces. The construction and
+extension callbacks allow additional rules for classes that already implement
+an interface.
+
+## Reflection and class loaders
+
+BeanShell applies additional target checks to these reflective operations when
+they are invoked through the interpreter:
+
+| Reflective call | Additional target callback |
+| --- | --- |
+| `Method.invoke(...)` | `canInvokeMethod(...)` or `canInvokeStaticMethod(...)` |
+| `Constructor.newInstance(...)` and `Class.newInstance()` | `canConstruct(...)` |
+| `Field.get(...)` | `canGetField(...)` or `canGetStaticField(...)` |
+| `Array.getLength(...)` | `canGetField(array, "length")` |
+
+For example, with the `List.size()` guard from the complete Java example, both
+of these BeanShell calls are rejected:
+
+```bsh
+list.size();
+java.util.List.class.getMethod("size", new Class[0])
+    .invoke(list, new Object[0]);
+```
+
+The two statements are alternative attempts: a rejection stops the current
+evaluation unless the script handles the error.
+
+An application can also use `canConstruct()` to reject a chosen class-loader
+type, or `canInvokeMethod()` to reject its `loadClass` calls. Match the receiver
+or requested class as well as the method name. For example, the predicate
+`receiver instanceof ClassLoader && "loadClass".equals(name)` identifies an
+instance call to a class loader's `loadClass` method. These rules apply at the
+intercepted operation; calling an allowed Java method does not instrument the
+compiled Java code that runs inside it.
+
+## Errors and scope
+
+The guard manager throws `bsh.security.SecurityError` when a callback rejects an
+operation. During script evaluation BeanShell converts it into an `EvalError`,
+whose message includes `SecurityError:`. Embedding applications should handle
+`EvalError` from `Interpreter.eval()`; `EvalError` can also report unrelated
+evaluation failures.
+
+The built-in guard rejects direct script access to the registry and direct
+attempts to construct or manipulate guard objects. Application-specific rules
+are supplied by the host application. The callbacks cover the operations listed
+above; this API does not provide field-write callbacks or execution-time and
+memory limits. The reflection table describes specific supported paths, rather
+than a guarantee covering every reflective API.
+
+See the [SecurityGuard source and tests in #772](https://github.com/beanshell/beanshell/pull/772/files)
+and the [documentation discussion in #770](https://github.com/beanshell/beanshell/issues/770)
+for the implementation and the original examples on which this page is based.

--- a/src/main/java/bsh/BSHAllocationExpression.java
+++ b/src/main/java/bsh/BSHAllocationExpression.java
@@ -32,6 +32,8 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CompletionException;
 
+import bsh.security.SecurityError;
+
 /**
     New object, new array, or inner class style allocation with body.
 */

--- a/src/main/java/bsh/Interpreter.java
+++ b/src/main/java/bsh/Interpreter.java
@@ -41,6 +41,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
+import bsh.security.MainSecurityGuard;
+
 /**
     The BeanShell script interpreter.
 

--- a/src/main/java/bsh/Name.java
+++ b/src/main/java/bsh/Name.java
@@ -812,8 +812,8 @@ class Name implements java.io.Serializable
                 Object instance = classNameSpace.getClassInstance();
                 Class<?> classStatic = classNameSpace.classStatic;
 
-                // Validate if can invoke this super method
-                Interpreter.mainSecurityGuard.canInvokeSuperMethod(instance.getClass().getSuperclass(), instance, methodName, args);
+                // Validate if can invoke this method
+                Interpreter.mainSecurityGuard.canInvokeMethod(instance, methodName, args);
 
                 return ClassGenerator.getClassGenerator()
                     .invokeSuperclassMethod( bcm, instance, classStatic, methodName, args );

--- a/src/main/java/bsh/Reflect.java
+++ b/src/main/java/bsh/Reflect.java
@@ -1297,4 +1297,10 @@ public final class Reflect {
         .filter(Objects::nonNull)
         .toArray(len -> (T[]) Array.newInstance(enm, len));
     }
+
+    /** Find the type of an object. */
+    public static Class<?> getType(Object arg) {
+        return Types.getType(arg);
+    }
+
 }

--- a/src/main/java/bsh/Types.java
+++ b/src/main/java/bsh/Types.java
@@ -774,25 +774,4 @@ class Types {
             || Entry.class.isAssignableFrom(clas);
     }
 
-    /**
-     * Just a method to return the pretty name of any Class
-     *
-     * <pre>
-     * prettyName(String.class)
-     *  returns "java.lang.String"
-     * prettyName(byte.class)
-     *  returns "byte"
-     * prettyName((new Object[3]).getClass())
-     *  returns "java.lang.Object[];"
-     * prettyName((new int[3][4][5][6][7][8][9]).getClass())
-     *  returns "int[][][][][][][]"
-     * </pre>
-     */
-    public static String prettyName(Class<?> clas) {
-        if (!clas.isArray()) return clas.getName();
-
-        // Return a string like "int[]", "double[]", "double[][]", etc...
-        Class<?> arrayType = clas.getComponentType();
-        return prettyName(arrayType) + "[]";
-    }
 }

--- a/src/main/java/bsh/security/MainSecurityGuard.java
+++ b/src/main/java/bsh/security/MainSecurityGuard.java
@@ -1,4 +1,4 @@
-package bsh;
+package bsh.security;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
@@ -8,15 +8,19 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import bsh.Interpreter;
+import bsh.Primitive;
+import bsh.Reflect;
+
 /**
  * It's the "main" SecurityGuard that must be used to real validate something.
  * This class store some implementations of {@link SecurityGuard} that each has some specific validation
  */
-final class MainSecurityGuard {
+public final class MainSecurityGuard {
 
     private final Set<SecurityGuard> securityGuards = new HashSet<SecurityGuard>();
 
-    MainSecurityGuard() {
+    public MainSecurityGuard() {
         this.securityGuards.add(new BasicSecurityGuard());
     }
 
@@ -25,13 +29,13 @@ final class MainSecurityGuard {
         this.securityGuards.add(guard);
     }
 
-    /** Remove a SecurityGuard that is being used. Return if it really contained this SecurityGuard */
-    public boolean remove(SecurityGuard guard) {
-        return this.securityGuards.remove(guard);
+    /** Remove a SecurityGuard if it's being used */
+    public void remove(SecurityGuard guard) {
+        this.securityGuards.remove(guard);
     }
 
     /** Validate if you can create a instance */
-    void canConstruct(Class<?> _class, Object[] args) throws SecurityError {
+    public void canConstruct(Class<?> _class, Object[] args) throws SecurityError {
         final Object[] _args = Primitive.unwrap(args);
         for (SecurityGuard guard: this.securityGuards)
             if (!guard.canConstruct(_class, _args))
@@ -39,7 +43,7 @@ final class MainSecurityGuard {
     }
 
     /** Validate if a specific static method of a specific class can be invoked */
-    void canInvokeStaticMethod(Class<?> _class, String methodName, Object[] args) throws SecurityError {
+    public void canInvokeStaticMethod(Class<?> _class, String methodName, Object[] args) throws SecurityError {
         final Object[] _args = Primitive.unwrap(args);
         this.canInvokeStaticMethodImpl(_class, methodName, _args);
         this.canInvokeStaticMethodImplToReflectionCanGetArrayLength(_class, methodName, _args);
@@ -66,7 +70,7 @@ final class MainSecurityGuard {
     }
 
     /** Validate if a specific method of a specific object can be invoked. */
-    void canInvokeMethod(Object thisArg, String methodName, Object[] args) throws SecurityError {
+    public void canInvokeMethod(Object thisArg, String methodName, Object[] args) throws SecurityError {
         final Object[] _args = Primitive.unwrap(args);
         this.canInvokeMethodImpl(thisArg, methodName, _args);
         this.canInvokeMethodImplToReflectionCanGetField(thisArg, methodName, _args);
@@ -159,44 +163,36 @@ final class MainSecurityGuard {
     }
 
     /** Validate if can call a local method ( aka commands ) */
-    void canInvokeLocalMethod(String methodName, Object[] args) throws SecurityError {
+    public void canInvokeLocalMethod(String methodName, Object[] args) throws SecurityError {
         final Object[] _args = Primitive.unwrap(args);
         for (SecurityGuard guard: this.securityGuards)
             if (!guard.canInvokeLocalMethod(methodName, _args))
                 throw SecurityError.cantInvokeLocalMethod(methodName, _args);
     }
 
-    /** Validate if can call a method of super class */
-    void canInvokeSuperMethod(Class<?> superClass, Object thisArg, String methodName, Object[] args) throws SecurityError {
-        final Object[] _args = Primitive.unwrap(args);
-        for (SecurityGuard guard: this.securityGuards)
-            if (!guard.canInvokeSuperMethod(superClass, thisArg, methodName, _args))
-                throw SecurityError.cantInvokeSuperMethod(superClass, methodName, _args);
-    }
-
     /** Validate if can get a field of a specific object */
-    void canGetField(Object thisArg, String fieldName) throws SecurityError {
+    public void canGetField(Object thisArg, String fieldName) throws SecurityError {
         for (SecurityGuard guard: this.securityGuards)
             if (!guard.canGetField(thisArg, fieldName))
                 throw SecurityError.cantGetField(thisArg, fieldName);
     }
 
     /** Validate if can get a static field of a specific class */
-    void canGetStaticField(Class<?> _class, String fieldName) throws SecurityError {
+    public void canGetStaticField(Class<?> _class, String fieldName) throws SecurityError {
         for (SecurityGuard guard: this.securityGuards)
             if (!guard.canGetStaticField(_class, fieldName))
                 throw SecurityError.cantGetStaticField(_class, fieldName);
     }
 
     /** Validate if {@link _class} can extends {@link superClass} */
-    void canExtends(Class<?> superClass) throws SecurityError {
+    public void canExtends(Class<?> superClass) throws SecurityError {
         for (SecurityGuard guard: this.securityGuards)
             if (!guard.canExtends(superClass))
                 throw SecurityError.cantExtends(superClass);
     }
 
     /** Validate if {@link _class} can implements {@link _interface} */
-    void canImplements(Class<?> _interface) throws SecurityError {
+    public void canImplements(Class<?> _interface) throws SecurityError {
         for (SecurityGuard guard: this.securityGuards)
             if (!guard.canImplements(_interface))
                 throw SecurityError.cantImplements(_interface);
@@ -204,6 +200,12 @@ final class MainSecurityGuard {
 
     /** It prevents the execution of codes that manipulate the SecurityGuard or MainSecurityGuard */
     private class BasicSecurityGuard implements SecurityGuard {
+
+        public boolean canConstruct(Class<?> _class, Object[] args) {
+            if (MainSecurityGuard.class.isAssignableFrom(_class)) return false;
+            if (SecurityGuard.class.isAssignableFrom(_class)) return false;
+            return true;
+        }
 
         public boolean canInvokeMethod(Object thisArg, String methodName, Object[] args) {
             return !(thisArg instanceof MainSecurityGuard);

--- a/src/main/java/bsh/security/SecurityError.java
+++ b/src/main/java/bsh/security/SecurityError.java
@@ -1,10 +1,13 @@
-package bsh;
+package bsh.security;
 
-import java.util.ArrayList;
-import java.util.List;
+import bsh.CallStack;
+import bsh.EvalError;
+import bsh.Node;
+import bsh.Reflect;
+import bsh.UtilEvalError;
 
 /** It's a specific error that is throwed when try to execute something that mustn't be executed */
-class SecurityError extends UtilEvalError {
+public class SecurityError extends UtilEvalError {
 
     SecurityError(String msg) {
         super("SecurityError: " + msg);
@@ -22,10 +25,12 @@ class SecurityError extends UtilEvalError {
 
     /** This method basically return the types of args at a concatened String by ", " */
     private static String argsTypesString(Object[] args) {
-        List<String> typesString = new ArrayList<String>();
-        for (Class<?> typeClass: Types.getTypes(args))
-            typesString.add(typeClass != null ? Types.prettyName(typeClass) : "null");
-        return String.join(", ", typesString);
+        String[] argTypeNames = new String[args.length];
+        for (int i = 0; i < args.length; i++) {
+            final Class<?> _class = Reflect.getType(args[i]);
+            argTypeNames[i] = _class != null ? _class.getTypeName() : "null";
+        }
+        return String.join(", ", argTypeNames);
     }
 
     /** Create a error for when can't construct a instance */
@@ -42,29 +47,25 @@ class SecurityError extends UtilEvalError {
 
     /** Create a error for when can't invoke a static method */
     static SecurityError cantInvokeStaticMethod(Class<?> _class, String methodName, Object[] args) {
-        String className = Types.prettyName(_class);
-        String msg = String.format("Can't invoke this static method: %s.%s(%s)", className, methodName, argsTypesString(args));
+        String msg = String.format("Can't invoke this static method: %s.%s(%s)", _class.getTypeName(), methodName, argsTypesString(args));
         return new SecurityError(msg);
     }
 
     /** Create a error for when can't invoke a static method using reflection */
     static SecurityError reflectCantInvokeStaticMethod(Class<?> _class, String methodName, Object[] args) {
-        String className = Types.prettyName(_class);
-        String msg = String.format("Can't invoke this static method using reflection: %s.%s(%s)", className, methodName, argsTypesString(args));
+        String msg = String.format("Can't invoke this static method using reflection: %s.%s(%s)", _class.getTypeName(), methodName, argsTypesString(args));
         return new SecurityError(msg);
     }
 
     /** Create a error for when can't invoke a method */
     static SecurityError cantInvokeMethod(Object thisArg, String methodName, Object[] args) {
-        String className = Types.prettyName(thisArg.getClass());
-        String msg = String.format("Can't invoke this method: %s.%s(%s)", className, methodName, argsTypesString(args));
+        String msg = String.format("Can't invoke this method: %s.%s(%s)", thisArg.getClass().getTypeName(), methodName, argsTypesString(args));
         return new SecurityError(msg);
     }
 
     /** Create a error for when can't invoke a method using reflection */
     static SecurityError reflectCantInvokeMethod(Object thisArg, String methodName, Object[] args) {
-        String className = Types.prettyName(thisArg.getClass());
-        String msg = String.format("Can't invoke this method using reflection: %s.%s(%s)", className, methodName, argsTypesString(args));
+        String msg = String.format("Can't invoke this method using reflection: %s.%s(%s)", thisArg.getClass().getTypeName(), methodName, argsTypesString(args));
         return new SecurityError(msg);
     }
 
@@ -74,50 +75,39 @@ class SecurityError extends UtilEvalError {
         return new SecurityError(msg);
     }
 
-    /** Create a error for when can't invoke a super method */
-    static SecurityError cantInvokeSuperMethod(Class<?> superClass, String methodName, Object[] args) {
-        String superClassName = Types.prettyName(superClass);
-        String msg = String.format("Can't invoke this super method: %s.%s(%s)", superClassName, methodName, argsTypesString(args));
-        return new SecurityError(msg);
-    }
-
     /** Create a error for when can't get a field */
     static SecurityError cantGetField(Object thisArg, String fieldName) {
-        String className = Types.prettyName(thisArg.getClass());
-        String msg = String.format("Can't get this field: %s.%s", className, fieldName);
+        String msg = String.format("Can't get this field: %s.%s", thisArg.getClass().getTypeName(), fieldName);
         return new SecurityError(msg);
     }
 
     /** Create a error for when can't get a field */
     static SecurityError reflectCantGetField(Object thisArg, String fieldName) {
-        String className = Types.prettyName(thisArg.getClass());
-        String msg = String.format("Can't get this field using reflection: %s.%s", className, fieldName);
+        String msg = String.format("Can't get this field using reflection: %s.%s", thisArg.getClass().getTypeName(), fieldName);
         return new SecurityError(msg);
     }
 
     /** Create a error for when can't get a field */
     static SecurityError cantGetStaticField(Class<?> _class, String fieldName) {
-        String className = Types.prettyName(_class);
-        String msg = String.format("Can't get this static field: %s.%s", className, fieldName);
+        String msg = String.format("Can't get this static field: %s.%s", _class.getTypeName(), fieldName);
         return new SecurityError(msg);
     }
 
     /** Create a error for when can't get a field */
     static SecurityError reflectCantGetStaticField(Class<?> _class, String fieldName) {
-        String className = Types.prettyName(_class);
-        String msg = String.format("Can't get this static field using reflection: %s.%s", className, fieldName);
+        String msg = String.format("Can't get this static field using reflection: %s.%s", _class.getTypeName(), fieldName);
         return new SecurityError(msg);
     }
 
     /** Create a error for when a class can't extends another class */
     static SecurityError cantExtends(Class<?> superClass) {
-        String msg = String.format("This class can't be extended: %s", superClass.getName());
+        String msg = String.format("Can't extend this class: %s", superClass.getName());
         return new SecurityError(msg);
     }
 
     /** Create a error for when a class can't implements an interface */
     static SecurityError cantImplements(Class<?> _interface) {
-        String msg = String.format("This interface can't be implemented: %s", _interface.getName());
+        String msg = String.format("Can't implement this interface: %s", _interface.getName());
         return new SecurityError(msg);
     }
 

--- a/src/main/java/bsh/security/SecurityGuard.java
+++ b/src/main/java/bsh/security/SecurityGuard.java
@@ -1,4 +1,4 @@
-package bsh;
+package bsh.security;
 
 /** It's the interface to implement a single SecurityGuard to be used by MainSecurityGuard */
 public interface SecurityGuard {
@@ -27,10 +27,7 @@ public interface SecurityGuard {
         return true;
     }
 
-    /** Validate and return if can call a method of super class */
-    public default boolean canInvokeSuperMethod(Class<?> superClass, Object thisArg, String methodName, Object[] args) {
-        return true;
-    }
+    // TODO: implement a 'canSetField' and 'canSetStaticField'
 
     /** Validate and return if can get a field of a specific object */
     public default boolean canGetField(Object thisArg, String fieldName) {

--- a/src/test/java/SimpleSecurityGuardTest.java
+++ b/src/test/java/SimpleSecurityGuardTest.java
@@ -1,0 +1,969 @@
+import java.io.File;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import bsh.FilteredTestRunner;
+import bsh.Interpreter;
+import bsh.TestUtil;
+import bsh.security.MainSecurityGuard;
+import bsh.security.SecurityGuard;
+
+// Note: this class has almost all tests from bsh.security.SecurityGuardTest, the idea of this class is to ensure that we won't have package visibility issues again!
+@RunWith(FilteredTestRunner.class)
+public class SimpleSecurityGuardTest {
+
+    public static class MySecurityGuard implements SecurityGuard {}
+
+    /**
+     * It's an empty implementation of SecurityGuard, so it basically does nothing.
+     * It's just to make the default implementations of the methods be covedered by tests, in another words, it's just to increase the code coverage.
+     */
+    private static final SecurityGuard emptySecurityGuard = new SecurityGuard() {};
+
+    /** It's an implementation of SecurityGuard just to execute the tests */
+    private static final SecurityGuard mySecurityGuard = new SecurityGuard() {
+        public boolean canConstruct(Class<?> _class, Object[] args) {
+            if (_class == File.class) return false;
+            return true;
+        }
+        public boolean canInvokeStaticMethod(Class<?> _class, String methodName, Object[] args) {
+            if (_class == System.class && methodName.equals("exit"))
+                return false;
+            return true;
+        }
+        public boolean canInvokeMethod(Object thisArg, String methodName, Object[] args) {
+            if (thisArg instanceof List && methodName.equals("add") && args[0] instanceof Number) return false;
+            if (methodName.equals("someMethod")) return false;
+            return true;
+        }
+        public boolean canInvokeLocalMethod(String methodName, Object[] args) {
+            if (methodName.equals("eval")) return false;
+            return true;
+        }
+        public boolean canGetField(Object thisArg, String fieldName) {
+            if (fieldName.equals("nums2")) return false;
+            return true;
+        }
+        public boolean canGetStaticField(Class<?> _class, String fieldName) {
+            if (fieldName.equals("num")) return false;
+            return true;
+        }
+        public boolean canExtends(Class<?> superClass) {
+            if (superClass == File.class) return false;
+            return true;
+        }
+        public boolean canImplements(Class<?> _interface) {
+            if (_interface == List.class) return false;
+            return true;
+        }
+    };
+
+    @BeforeClass
+    public static void beforeAll() {
+        Interpreter.mainSecurityGuard.add(SimpleSecurityGuardTest.emptySecurityGuard);
+        Interpreter.mainSecurityGuard.add(SimpleSecurityGuardTest.mySecurityGuard);
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        Interpreter.mainSecurityGuard.remove(SimpleSecurityGuardTest.emptySecurityGuard);
+        Interpreter.mainSecurityGuard.remove(SimpleSecurityGuardTest.mySecurityGuard);
+    }
+
+    @Test
+    public void can_construct() {
+        try {
+            TestUtil.eval("var obj = new java.util.HashMap();");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_construct() {
+        try {
+            TestUtil.eval("var obj = new java.io.File(\"\");");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't call this construct: new java.io.File(java.lang.String)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_construct_using_legacy_reflection() {
+        try {
+            TestUtil.eval("var obj = HashMap.class.newInstance()");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_construct_using_legacy_reflection() {
+        try {
+            TestUtil.eval("var obj = File.class.newInstance();");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't call this construct using reflection: new java.io.File()";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_construct_using_reflection() {
+        try {
+            TestUtil.eval("var obj = HashMap.class.getConstructor(new Class[] {}).newInstance(new Object[] {});");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_construct_using_reflection() {
+        try {
+            TestUtil.eval("var obj = File.class.getConstructor(new Class[] { String.class }).newInstance(new Object[] { \"\" });");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't call this construct using reflection: new java.io.File(java.lang.String)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_construct_using_reflection_with_varargs() {
+        try {
+            TestUtil.eval("var obj = HashMap.class.getConstructor().newInstance();");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_construct_using_reflection_with_varargs() {
+        try {
+            TestUtil.eval("var obj = File.class.getConstructor(String.class).newInstance(\"\");");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't call this construct using reflection: new java.io.File(java.lang.String)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method() {
+        try {
+            TestUtil.eval("System.getProperty(\"java.version\");");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method() {
+        try {
+            TestUtil.eval("System.exit(1);");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method_within_local_method() {
+        try {
+            TestUtil.eval("void func() { System.getProperty(\"java.version\"); }; func();");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method_within_local_method() {
+        try {
+            TestUtil.eval("void func() { System.exit(1); }; func()");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method_using_reflection() {
+        try {
+            TestUtil.eval(
+                "import java.lang.reflect.Method;",
+                "Method method = System.class.getMethod(\"getProperty\", new Class[] { String.class });",
+                "method.invoke(null, new Object[] { \"java.version\" });"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method_using_reflection() {
+        try {
+            TestUtil.eval(
+                "import java.lang.reflect.Method;",
+                "Method method = System.class.getMethod(\"exit\", new Class[] { int.class });",
+                "method.invoke(null, new Object[] { 1 });"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method using reflection: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method_using_reflection_with_varargs() {
+        try {
+            TestUtil.eval(
+                "import java.lang.reflect.Method;",
+                "Method method = System.class.getMethod(\"getProperty\", String.class);",
+                "method.invoke(null, \"java.version\");"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method_using_reflection_with_varargs() {
+        try {
+            TestUtil.eval(
+                "import java.lang.reflect.Method;",
+                "Method method = System.class.getMethod(\"exit\", int.class);",
+                "method.invoke(null, 1);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method using reflection: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method_within_class_method() {
+        try {
+            TestUtil.eval(
+                "class Test { void exec() { System.getProperty(\"java.version\"); } }; ",
+                "new Test().exec();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method_within_class_method() {
+        try {
+            TestUtil.eval(
+                "class Test { void exec() { System.exit(1); } }; ",
+                "new Test().exec();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method_within_class_static_method() {
+        try {
+            TestUtil.eval(
+                "class Test { static void exec() { System.getProperty(\"java.version\"); } };",
+                "Test.exec();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method_within_class_static_method() {
+        try {
+            TestUtil.eval(
+                "class Test { static void exec() { System.exit(1); } };",
+                "Test.exec();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method_within_enum_static_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; static void exec() { System.getProperty(\"java.version\"); } };",
+                "Test.exec();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method_within_enum_static_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; static void exec() { System.exit(1); } };",
+                "Test.exec();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_static_method_within_enum_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; void exec() { System.getProperty(\"java.version\"); } };",
+                "Test.AB.exec()"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_static_method_within_enum_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; void exec() { System.exit(1); } };",
+                "Test.AB.exec()"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this static method: java.lang.System.exit(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "new ArrayList().size();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "new ArrayList().add(1);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_within_local_method() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "void func() { new ArrayList().size(); }",
+                "func();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_within_local_method() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "void func() { new ArrayList().add(1); }",
+                "func();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_using_reflection() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "var method = ArrayList.class.getMethod(\"add\", Object.class);",
+                "var list = new ArrayList();",
+                "method.invoke(list, new Object[] { \"1\" });"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_using_reflection() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "var method = ArrayList.class.getMethod(\"add\", Object.class);",
+                "var list = new ArrayList();",
+                "method.invoke(list, new Object[] { 1 });"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method using reflection: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_using_reflection_with_varargs() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "var method = ArrayList.class.getMethod(\"add\", Object.class);",
+                "var list = new ArrayList();",
+                "method.invoke(list, \"1\");"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_using_reflection_with_varargs() {
+        try {
+            TestUtil.eval(
+                "import java.util.ArrayList;",
+                "var method = ArrayList.class.getMethod(\"add\", Object.class);",
+                "var list = new ArrayList();",
+                "method.invoke(list, 1);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method using reflection: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_using_reflection_with_multiple_varargs() {
+        try {
+            TestUtil.eval(
+                "class MyList extends ArrayList { public void add(String a, String b, String c) {} }",
+                "var method = MyList.class.getMethod(\"add\", String.class, String.class, String.class);",
+                "var list = new MyList();",
+                "method.invoke(list, \"1\", \"2\", \"3\");"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_using_reflection_with_multiple_varargs() {
+        try {
+            TestUtil.eval(
+                "class MyList extends ArrayList { public void add(int a, int b, int c) {} }",
+                "var method = MyList.class.getMethod(\"add\", int.class, int.class, int.class);",
+                "var list = new MyList();",
+                "method.invoke(list, 1, 2, 3);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method using reflection: MyList.add(java.lang.Integer, java.lang.Integer, java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_within_class_method() {
+        try {
+            TestUtil.eval(
+                "class Test { void exec() { new ArrayList().size(); } }; ",
+                "new Test().exec();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_within_class_method() {
+        try {
+            TestUtil.eval(
+                "class Test { void exec() { new ArrayList().add(1); } };",
+                "new Test().exec();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_within_class_static_method() {
+        try {
+            TestUtil.eval(
+                "class Test { void exec() { new ArrayList().size(); } }; ",
+                "new Test().exec();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            System.out.println("Error: " + ex);
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_within_class_static_method() {
+        try {
+            TestUtil.eval(
+                "class Test { static void exec() { new ArrayList().add(1); } };",
+                "Test.exec();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_within_enum_static_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; static void exec() { new ArrayList().size(); } };",
+                "Test.exec();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_within_enum_static_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; static void exec() { new ArrayList().add(1); } };",
+                "Test.exec();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_method_within_enum_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; void exec() { new ArrayList().size(); } };",
+                "Test.AB.exec()"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_method_within_enum_method() {
+        try {
+            TestUtil.eval(
+                "enum Test { AB; void exec() { new ArrayList().add(1); } };",
+                "Test.AB.exec()"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: java.util.ArrayList.add(java.lang.Integer)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_local_method() {
+        try {
+            TestUtil.eval(
+                "int doubleIt(int num) { return num * 2; }",
+                "doubleIt(20);"
+                );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_local_method() {
+        try {
+            TestUtil.eval("eval(\"return 123;\")");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this local method: eval(java.lang.String)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_invoke_super_method() {
+        try {
+            TestUtil.eval(
+                "class Cls1 { int exec() { return 1; } };",
+                "class Cls2 extends Cls1 { int method2() { return super.exec(); } };",
+                "new Cls2().method2();"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_invoke_super_method() {
+        try {
+            TestUtil.eval(
+                "class Cls1 { int someMethod() { return 1; } };",
+                "class Cls2 extends Cls1 { int method() { return super.someMethod(); } };",
+                "new Cls2().method();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: Cls2.someMethod()";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_get_field() {
+        try {
+            TestUtil.eval(
+                "class Cls1 { int[] nums = {1, 2, 3}; };",
+                "var myObj = new Cls1(); myObj.nums;"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_get_field() {
+        try {
+            TestUtil.eval(
+                "class Cls1 { int[] nums2 = {1, 2, 3}; };",
+                "var myObj = new Cls1();",
+                "myObj.nums2;",
+                "field.get(myObj);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't get this field: Cls1.nums2";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_get_array_length_field() {
+        try {
+            TestUtil.eval(
+                "class Cls1 { int[] nums = {1, 2, 3}; };",
+                "var myObj = new Cls1(); myObj.nums.length;"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_get_array_length_field() {
+        final SecurityGuard arrayLengthSecurityGuard = new SecurityGuard() {
+            public boolean canGetField(Object thisArg, String fieldName) {
+                return !fieldName.equals("length");
+            }
+        };
+        Interpreter.mainSecurityGuard.add(arrayLengthSecurityGuard);
+
+        try {
+            TestUtil.eval(
+                "class Cls1 { int[] nums = {1, 2, 3}; };",
+                "var myObj = new Cls1(); myObj.nums.length;"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't get this field: int[].length";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+
+        Interpreter.mainSecurityGuard.remove(arrayLengthSecurityGuard);
+    }
+
+    @Test
+    public void can_get_field_using_reflection() {
+        try {
+            TestUtil.eval(
+                "class Cls1 { int[] nums = {1, 2, 3}; }",
+                "var myObj = new Cls1();",
+                "var field = Cls1.class.getField(\"nums\");",
+                "field.get(myObj);"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_get_field_using_reflection() {
+        try {
+            TestUtil.eval(
+                "class Cls1 { int[] nums2 = {1, 2, 3}; };",
+                "var myObj = new Cls1();",
+                "var field = Cls1.class.getField(\"nums2\");",
+                "field.get(myObj);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't get this field using reflection: Cls1.nums2";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_get_array_length_field_using_reflection() {
+        try {
+            TestUtil.eval(
+                "import java.lang.reflect.Array;",
+                "int[] nums = {1, 2, 3};",
+                "Array.getLength(nums);"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_get_array_length_field_using_reflection() {
+        final SecurityGuard arrayLengthSecurityGuard = new SecurityGuard() {
+            public boolean canGetField(Object thisArg, String fieldName) {
+                return !fieldName.equals("length");
+            }
+        };
+        Interpreter.mainSecurityGuard.add(arrayLengthSecurityGuard);
+
+        try {
+            TestUtil.eval(
+                "import java.lang.reflect.Array;",
+                "int[] nums = {1, 2, 3};",
+                "Array.getLength(nums);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't get this field using reflection: int[].length";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+
+        Interpreter.mainSecurityGuard.remove(arrayLengthSecurityGuard);
+    }
+
+    @Test
+    public void can_get_static_field() {
+        try {
+            TestUtil.eval(
+                "class Cls { static int nums = 1; };",
+                "Cls.nums;"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_get_static_field() {
+        try {
+            TestUtil.eval(
+                "class Cls { static int num = 1; };",
+                "Cls.num;"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't get this static field: Cls.num";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_get_static_field_using_reflection() {
+        try {
+            TestUtil.eval(
+                "class Cls { static int nums = 1; };",
+                "var field = Cls.class.getField(\"nums\");",
+                "field.get(null);"
+            );
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_get_static_field_using_reflection() {
+        try {
+            TestUtil.eval(
+                "class Cls { static int num = 1; };",
+                "var field = Cls.class.getField(\"num\");",
+                "field.get(null);"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't get this static field using reflection: Cls.num";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_extends() {
+        try {
+            TestUtil.eval("class MyClass extends java.util.HashMap { }");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_extends() {
+        try {
+            TestUtil.eval("class MyClass extends java.io.File { }");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't extend this class: java.io.File";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void can_implements() {
+        try {
+            TestUtil.eval("interface EmptyInterface {}; class MyClass implements EmptyInterface { }");
+            Assert.assertTrue(true);
+        } catch (Exception ex) {
+            Assert.fail("The code mustn't throw any Exception!");
+        }
+    }
+
+    @Test
+    public void cant_implements() {
+        try {
+            TestUtil.eval("class MyClass implements java.util.List { }");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't implement this interface: java.util.List";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void cant_use_security_guard_API_1st() {
+        try {
+            TestUtil.eval(
+                "import bsh.security.SecurityGuard;",
+                "class MySecuryGuard implements SecurityGuard {}"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't implement this interface: bsh.security.SecurityGuard";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void cant_use_security_guard_API_2nd() {
+        try {
+            TestUtil.eval(
+                "import bsh.Interpreter;",
+                "Interpreter.mainSecurityGuard;"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't get this static field: bsh.Interpreter.mainSecurityGuard";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void cant_use_security_guard_API_3rd() {
+        try {
+            Interpreter bsh = new Interpreter();
+            bsh.set("mainSG", new MainSecurityGuard());
+            bsh.eval("mainSG.add(new java.util.HashMap());");
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't invoke this method: bsh.security.MainSecurityGuard.add(java.util.HashMap)";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+    @Test
+    public void cant_instantiate_security_guard() {
+        try {
+            TestUtil.eval(
+                "import SimpleSecurityGuardTest.MySecurityGuard;",
+                "new MySecurityGuard();"
+            );
+            Assert.fail("The code must throw an Exception!");
+        } catch (Exception ex) {
+            final String expectedMsg = "SecurityError: Can't call this construct: new SimpleSecurityGuardTest$MySecurityGuard()";
+            Assert.assertTrue("Unexpected Exception Message: " + ex, ex.toString().contains(expectedMsg));
+        }
+    }
+
+}

--- a/src/test/java/bsh/TypesTest.java
+++ b/src/test/java/bsh/TypesTest.java
@@ -430,22 +430,4 @@ public class TypesTest {
         Assert.assertTrue(Types.isBshAssignable(Object.class, Integer.TYPE));
     }
 
-    /** Test {@link Types#prettyName(Class)} with primitive Class<?>, e.g.: <b>byte</b>, <b>int</b>, <b>char</b>, etc... */
-    @Test
-    public void pretty_name_of_primitive() {
-        Assert.assertEquals("byte", Types.prettyName(byte.class));
-    }
-
-    /** Test {@link Types#prettyName(Class)} with an array Class<?>, e.g.: <b>java.lang.Object[]</b> */
-    @Test
-    public void pretty_name_of_array() {
-        Assert.assertEquals("java.lang.Object[]", Types.prettyName(new Object[3].getClass()));
-    }
-
-    /** Test {@link Types#prettyName(Class)} with an matrix Class<?>, e.g.: <b>java.lang.Object[][][][][]</b> */
-    @Test
-    public void pretty_name_of_matrix() {
-        Assert.assertEquals("int[][][][][][][]", Types.prettyName(new int[3][4][5][6][7][8][9].getClass()));
-    }
-
 }


### PR DESCRIPTION
Fixes #770.

Add a repository SecurityGuard guide, linked from the README, so embedding applications have a complete Java example and a reference for the callback API. The guide corrects the wiki's method-filter example, explains registration/removal and the shared registry, covers supported reflective checks and evaluation errors, and documents the API changes in #772.

This branch is based on #772 head `68d0e72606b126850a6eb9201f63fc3e063e51e4`, preserving its original commit and author credit. The `bsh.security` imports and external guard registration rely on that PR. Our additional commit changes only `SecurityGuard.md` and its README link; #772's implementation is unchanged. The guide credits the original documentation and examples.

Validation:

- All eight Java examples compile with JDK 8 against the exact #772 artifact, and the complete embedding example runs as documented.
- Seventeen behavior checks pass, covering permitted setup operations, all seven policy examples, and direct/reflective rejection of `List.size()`.
- Markdown fences, both tables, and `git diff --check` pass.
- The unchanged #772 base separately passed JDK 8 `mvn -B -ntp clean verify`: 759 tests, 6 skipped, zero failures/errors and zero Checkstyle violations. The documentation commit was validated with the example checks above.
