### PR TITLE
Fix invalid generic signatures on generated members

### DIFF
--- a/src/main/java/bsh/ClassGeneratorUtil.java
+++ b/src/main/java/bsh/ClassGeneratorUtil.java
@@ -336,18 +336,6 @@ public class ClassGeneratorUtil implements Opcodes {
         cw.visitField(modifiers, fieldName, type, null/*signature*/, value);
     }
 
-    /**
-     * Build the signature for the supplied parameter types.
-     * @param paramTypes list of parameter types
-     * @return parameter type signature
-     */
-    private static String getTypeParameterSignature(String[] paramTypes) {
-        StringBuilder sb = new StringBuilder("<");
-        for (final String pt : paramTypes)
-            sb.append(pt).append(":");
-        return sb.toString();
-    }
-
     /** Generate support code needed for Enum types.
      * Generates enum values and valueOf methods, default private constructor with initInstance call.
      * Instead of maintaining a synthetic array of enum values we greatly reduce the required bytecode
@@ -419,10 +407,8 @@ public class ClassGeneratorUtil implements Opcodes {
 
         String methodDescriptor = getMethodDescriptor(returnType, paramTypes);
 
-        String paramTypesSig = getTypeParameterSignature(paramTypes);
-
         // Generate method body
-        MethodVisitor cv = cw.visitMethod(modifiers, methodName, methodDescriptor, paramTypesSig, exceptions);
+        MethodVisitor cv = cw.visitMethod(modifiers, methodName, methodDescriptor, null/*signature*/, exceptions);
 
         if ((modifiers & ACC_ABSTRACT) != 0)
             return;
@@ -467,10 +453,8 @@ public class ClassGeneratorUtil implements Opcodes {
         String[] exceptions = null;
         String methodDescriptor = getMethodDescriptor("V", paramTypes);
 
-        String paramTypesSig = getTypeParameterSignature(paramTypes);
-
         // Create this constructor method
-        MethodVisitor cv = cw.visitMethod(modifiers, "<init>", methodDescriptor, paramTypesSig, exceptions);
+        MethodVisitor cv = cw.visitMethod(modifiers, "<init>", methodDescriptor, null/*signature*/, exceptions);
 
         // Generate code to push arguments as an object array
         generateParameterReifierCode(paramTypes, false/*isStatic*/, cv);
@@ -695,10 +679,8 @@ public class ClassGeneratorUtil implements Opcodes {
 
         String methodDescriptor = getMethodDescriptor(returnType, paramTypes);
 
-        String paramTypesSig = getTypeParameterSignature(paramTypes);
-
         // Add method body
-        MethodVisitor cv = cw.visitMethod(modifiers, "_bshSuper" + superClass.getSimpleName() + methodName, methodDescriptor, paramTypesSig, exceptions);
+        MethodVisitor cv = cw.visitMethod(modifiers, "_bshSuper" + superClass.getSimpleName() + methodName, methodDescriptor, null/*signature*/, exceptions);
 
         cv.visitVarInsn(ALOAD, 0);
         // Push vars

--- a/src/test/java/bsh/ClassGeneratorTest.java
+++ b/src/test/java/bsh/ClassGeneratorTest.java
@@ -21,6 +21,7 @@
 package bsh;
 
 import static bsh.TestUtil.eval;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -104,6 +105,25 @@ public class ClassGeneratorTest {
         assertEquals("chained:direct", eval(script.toString(),
                 "return new LargeConstructorDispatch().result + \":\""
                 + " + new LargeConstructorDispatch(\"direct\").result;"));
+    }
+
+    @Test
+    public void generated_members_have_valid_generic_parameter_metadata() throws Exception {
+        Class<?> type = (Class<?>) eval(
+                "class SignatureProbe extends java.util.ArrayList {",
+                    "SignatureProbe(int value) {}",
+                    "void probe(String value) {}",
+                    "public boolean add(Object value) { return super.add(value); }",
+                "}",
+                "return SignatureProbe.class;");
+
+        assertArrayEquals(new Class<?>[] { int.class }, type
+                .getDeclaredConstructor(int.class).getGenericParameterTypes());
+        assertArrayEquals(new Class<?>[] { String.class }, type
+                .getDeclaredMethod("probe", String.class).getGenericParameterTypes());
+        assertArrayEquals(new Class<?>[] { Object.class }, type
+                .getDeclaredMethod("_bshSuperArrayListadd", Object.class)
+                .getGenericParameterTypes());
     }
 
 


### PR DESCRIPTION
Generated methods and constructors currently receive a JVM `Signature` attribute assembled from erased parameter descriptors. For example, an `int` parameter produces a string beginning with `<I:`, which is not a valid generic signature. Generated classes load normally, but reflective calls such as `getGenericParameterTypes()` fail with `GenericSignatureFormatError` when the attribute is parsed.

Omit the optional generic signature for generated methods, constructors, and `_bshSuper` delegates. Their JVM descriptors remain unchanged, so reflection now reports the erased parameter types. This deliberately does not attempt to generate generic metadata that the generator does not currently preserve.