### PR TITLE
Fix classpath feedback assertion on Windows

### DIFF
--- a/src/test/java/bsh/classpath/BshClassPathTest.java
+++ b/src/test/java/bsh/classpath/BshClassPathTest.java
@@ -113,7 +113,7 @@ public class BshClassPathTest {
         bcp.add(new URL[] { new URL("file:/unknown/path") });
         bcp.add(new URL("file:/unknown/path"));
         assertThat("Got feedback error", cpmf.err,
-                equalTo("Not a classpath component: /unknown/path"));
+                equalTo("Not a classpath component: " + new File("/unknown/path").getPath()));
     }
 
     @Test


### PR DESCRIPTION
Classpath mapping feedback now reports file URLs through `File.getPath()`, so the existing test receives platform-native path separators. Its hard-coded Unix path fails on Windows even though the reported path is correct.

Build the expected path through `File` as well. Unix-like systems continue to expect `/unknown/path`, Windows expects `\unknown\path`, and production behavior remains unchanged.