### PR TITLE
Fix Object arrays passed to typed Java varargs

### DIFF
--- a/src/main/java/bsh/BSHAllocationExpression.java
+++ b/src/main/java/bsh/BSHAllocationExpression.java
@@ -232,6 +232,8 @@ class BSHAllocationExpression extends SimpleNode
         if ( lastIndex < 0 || lastIndex > arguments.values.length )
             return arguments.values;
         Class<?> arrayType = con.getParameterTypes()[lastIndex];
+        Object[] source = arguments.values;
+        int sourceIndex = lastIndex;
         // The caller may have passed the array itself rather than a tail. This
         // is the declared type, not the value: (Object[])null and (Object)null
         // are both a null value and only the type tells them apart.
@@ -239,17 +241,21 @@ class BSHAllocationExpression extends SimpleNode
             Class<?> lastType = arguments.types[lastIndex];
             if ( null == lastType || arrayType.isAssignableFrom(lastType) )
                 return arguments.values;
+            if ( lastType == Object[].class && arguments.values[lastIndex] instanceof Object[] ) {
+                source = (Object[]) arguments.values[lastIndex];
+                sourceIndex = 0;
+            }
         }
         Object[] wrapped = new Object[con.getParameterCount()];
         System.arraycopy(arguments.values, 0, wrapped, 0, lastIndex);
         // the tail has to be the constructor's own array type, not Object[],
         // or the super() call finds no matching constructor
         Class<?> component = arrayType.getComponentType();
-        int tail = arguments.values.length - lastIndex;
+        int tail = source.length - sourceIndex;
         Object varargs = Array.newInstance(component, tail);
         for ( int i = 0; i < tail; i++ )
             Array.set(varargs, i,
-                    con.coerceToType(arguments.values[lastIndex + i], component));
+                    con.coerceToType(source[sourceIndex + i], component));
         wrapped[lastIndex] = varargs;
         return wrapped;
     }

--- a/src/main/java/bsh/Invocable.java
+++ b/src/main/java/bsh/Invocable.java
@@ -17,6 +17,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
@@ -230,7 +231,10 @@ public abstract class Invocable implements Member {
                 || getParameterCount() != arguments.types.length + enclosing)
             return false;
         Class<?> last = arguments.types[arguments.types.length - 1];
-        return last == null || getVarArgsType().isAssignableFrom(last);
+        if (last == null || getVarArgsType().isAssignableFrom(last))
+            return true;
+        Object value = arguments.values[arguments.values.length - 1];
+        return last == Object[].class && value instanceof Object[];
     }
 
     /** Invoke using call-local types, leaving the cached method handle unchanged. */
@@ -355,7 +359,15 @@ abstract class ExecutingInvocable extends Invocable {
                 Object[] varargs;
                 if (fixedArity) {
                     isFixedArity = true;
-                    parameters.add(Primitive.unwrap(params[getLastParameterIndex()]));
+                    Object value = Primitive.unwrap(params[getLastParameterIndex()]);
+                    if (value instanceof Object[] && !getVarArgsType().isInstance(value)) {
+                        Object[] source = (Object[]) value;
+                        value = Array.newInstance(getVarArgsComponentType(), source.length);
+                        for (int i = 0; i < source.length; i++)
+                            Array.set(value, i, super.coerceToType(
+                                    source[i], getVarArgsComponentType()));
+                    }
+                    parameters.add(value);
                 } else {
                     varargs = Arrays.copyOfRange(
                             params, getLastParameterIndex(), params.length);

--- a/src/test/java/bsh/NullVarargsTest.java
+++ b/src/test/java/bsh/NullVarargsTest.java
@@ -239,4 +239,14 @@ public class NullVarargsTest {
             "import bsh.NullVarargsTest.TypedVarargs;",
             "return new TypedVarargs(){}.kind;"));
     }
+
+    @Test
+    public void anonymous_subclass_converts_an_object_array_varargs_tail() throws Exception {
+        assertEquals("String...2", TestUtil.eval(
+            "import bsh.NullVarargsTest.TypedVarargs;",
+            "return new TypedVarargs((Object[]){\"a\", \"b\"}){}.kind;"));
+        assertEquals("String...0", TestUtil.eval(
+            "import bsh.NullVarargsTest.TypedVarargs;",
+            "return new TypedVarargs((Object[]){}){}.kind;"));
+    }
 }

--- a/src/test/java/bsh/VarargsTest.java
+++ b/src/test/java/bsh/VarargsTest.java
@@ -67,6 +67,36 @@ public class VarargsTest {
         Assert.assertEquals(Arrays.<Object>asList(1,2,3), list);
     }
 
+    @Test
+    public void calling_java_typed_varargs_with_object_array() throws Exception {
+        final Interpreter interpreter = new Interpreter();
+        interpreter.set("helper", new ClassWithVarargMethods());
+        Object[] parameterTypes = {int.class, Object.class};
+        interpreter.set("parameterTypes", parameterTypes);
+        Assert.assertEquals(ArrayList.class.getDeclaredMethod("add", int.class, Object.class),
+                interpreter.eval("ArrayList.class.getDeclaredMethod(\"add\", (Object[]){int.class, Object.class})"));
+        Assert.assertEquals(ArrayList.class.getDeclaredMethod("add", int.class, Object.class),
+                interpreter.eval("ArrayList.class.getDeclaredMethod(\"add\", parameterTypes)"));
+        Assert.assertEquals(ArrayList.class.getDeclaredConstructor(),
+                interpreter.eval("ArrayList.class.getDeclaredConstructor((Object[]){})"));
+        Assert.assertEquals(ArrayList.class.getDeclaredMethod("add", int.class, Object.class),
+                interpreter.eval("ArrayList.class.getDeclaredMethod(\"add\", (Class[]){int.class, Object.class})"));
+        Assert.assertEquals(ArrayList.class.getDeclaredMethod("add", int.class, Object.class),
+                interpreter.eval("ArrayList.class.getDeclaredMethod(\"add\", int.class, Object.class)"));
+        Assert.assertArrayEquals(new int[] {2, 3},
+                (int[]) interpreter.eval("helper.ints((Object[]){2, 3})"));
+    }
+
+    @Test
+    public void incompatible_object_array_vararg_reports_element_cast() throws Exception {
+        final Interpreter interpreter = new Interpreter();
+        interpreter.set("parameterTypes", new Object[] {int.class, "not a class"});
+        TargetError error = Assert.assertThrows(TargetError.class, () -> interpreter.eval(
+                "ArrayList.class.getDeclaredMethod(\"add\", parameterTypes)"));
+        Assert.assertTrue(error.getTarget().getMessage(),
+                error.getTarget().getMessage().contains("Cannot cast String"));
+    }
+
     public static class ClassWithVarargMethods {
 
         public List<Object> list(final List<Object> list, final Object... args) {
@@ -76,6 +106,10 @@ public class VarargsTest {
 
         public List<Object> list(final Object... args) {
             return new ArrayList<Object>(Arrays.asList(args));
+        }
+
+        public int[] ints(final int... args) {
+            return args;
         }
 
     }


### PR DESCRIPTION
Passing an `Object[]` as the array argument to typed Java varargs currently treats the entire array as one vararg element. Calls such as `Class.getDeclaredMethod(..., (Object[]){...})` then try to cast `Object[]` to the component type instead of converting its elements to the declared array type.

Recognize a non-null `Object[]` in the fixed-arity position after member selection, convert its elements with the existing coercion rules, and invoke the member with the declared varargs array type. Already typed arrays, null arrays, and expanded varargs keep their existing behavior, while anonymous subclasses apply the same conversion before forwarding arguments to a typed-varargs superclass constructor. Method overload selection remains unchanged.
